### PR TITLE
Moving existing Showcase page info to the new site

### DIFF
--- a/showcase.md
+++ b/showcase.md
@@ -2,3 +2,186 @@
 _title: Showcase
 _description: A list of big hits to small gem titles created using MonoGame.
 ---
+
+There have been 1000s of games, libraries, and tolls made using MonoGame over the years.
+
+We have gathered a taste of those titles here from the big hits to the small hidden gems.
+
+If you are a developer and would like us to add your game to this list, please follow the instructions [here](https://community.monogame.net/t/new-monogame-showcase/10948).
+
+<div style="width:100%;max-width:1110px;margin:0 auto;display:flex;flex-wrap:wrap;justify-center: center;">
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/sor4-screenshot.jpg')">
+			<a href="https://www.streets4rage.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/sor4-logo.png') center center no-repeat" title="Streets of Rage 4"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/paladin-screenshot.jpg')">
+			<a href="http://pumpkin-games.net/paladin.php" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/paladin-logo.png') center center no-repeat" title="Paladin"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, XboxOne</div> -->
+		</div>
+        <div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/fhook-screenshot.png')">
+			<a href="http://flinthook.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/fhook-logo.png') center center no-repeat" title="Flinthook"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
+		</div>
+<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/mkings-screenshot.png')">
+			<a href="http://mercenarykings.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/mkings-logo.png') center center no-repeat" title="Mercenary Kings"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/goat2-screenshot.jpg')">
+			<a href="http://www.escapegoat2.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/goat2-logo.png') center center no-repeat" title="Escape Goat 2"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, PlayStation4</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/daryl-screenshot.jpg')">
+			<a href="https://danandgarygames.com/superdaryldeluxe" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/daryl-logo.png') center center no-repeat" title="Super Daryl Deluxe"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/chasm-screenshot.png')">
+			<a href="http://www.chasmgame.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/chasm-logo.png') center center no-repeat" title="Chasm"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/celeste-screenshot.png')">
+			<a href="http://www.celestegame.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/celeste-logo.png') center center no-repeat" title="Celeste"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/rblob-screenshot.png')">
+			<a href="http://www.rainingblobs.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/rblob-logo.png') center center no-repeat" title="Raining Blobs"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Android, Console, Desktop, Linux, Mac, Mobile, Windows, XboxOne</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bta-screenshot.jpg')">
+			<a href="https://www.eurekaexhibits.com/be-the-astronaut" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bta-logo.png') center center no-repeat" title="Be the Astronaut"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, 3D, Desktop, Windows</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/armed-screenshot.jpg')">
+			<a href="http://www.armedgame.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/armed-logo.png') center center no-repeat" title="ARMED!"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Desktop, Mobile, Windows, WindowsPhone</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/redungeon-screenshot.png')">
+			<a href="http://www.eneminds.com/redungeon/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/redungeon-logo.png') center center no-repeat" title="Redungeon"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Android, Featured, Mobile, iOS</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/squareheroes-screenshot.png')">
+			<a href="http://www.squareheroes.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/squareheroes-logo.png') center center no-repeat" title="Square Heroes"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Console, Featured, PlayStation4</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/wayward-screenshot.jpg')">
+			<a href="http://www.wtfrontier.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/wayward-logo.png') center center no-repeat" title="Wayward Terran Frontier"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Desktop, Featured, Windows</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bastion-screenshot.jpg')">
+			<a href="http://www.supergiantgames.com/games/bastion/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bastion-logo.png') center center no-repeat" title="Bastion"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Console, Desktop, Mac, PlayStation4</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/fez-screenshot.png')">
+			<a href="http://www.fezgame.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/fez-logo.png') center center no-repeat" title="Fez"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Desktop, Linux, Mac</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/skulls-screenshot.jpg')">
+			<a href="http://skullsoftheshogun.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/skulls-logo.png') center center no-repeat" title="Skulls of the Shogun"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Android, Console, Featured, Mobile, PlayStation4</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/ty-screenshot.jpg')">
+			<a href="http://www.kromestudios.com/TY/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/ty-logo.png') center center no-repeat" title="TY the Tasmanian Tiger 4"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Desktop, Featured, Windows</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/oldtimehockey-screenshot.jpg')">
+			<a href="http://www.bushhockeyleague.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/oth-logo.png') center center no-repeat" title="Bush Hockey League"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Console, Featured, PlayStation4, XboxOne</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/flight-screenshot.jpg')">
+			<a href="http://www.infinite-flight.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/flight-logo.png') center center no-repeat" title="Infinite Flight"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Android, Featured, Mobile, iOS</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/neurovoider-screenshot.jpg')">
+			<a href="http://www.neurovoider.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/neurovoider-logo.png') center center no-repeat" title="Neurovoider"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, PSVita, PlayStation4, Windows, XboxOne</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/apotheon-screenshot.jpg')">
+			<a href="http://www.apotheongame.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/apotheon-logo.png') center center no-repeat" title="Apotheon"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, PlayStation4</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/axiom-screenshot.png')">
+			<a href="http://www.axiomverge.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/axiom-logo.png') center center no-repeat" title="Axiom Verge"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/towerfall-screenshot.jpg')">
+			<a href="http://www.towerfall-game.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/towerfall-logo.png') center center no-repeat" title="Towerfall"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/stardew-screenshot.png')">
+			<a href="http://www.stardewvalley.net/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/stardew-logo4.png') center center no-repeat" title="Stardew Valley"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
+		</div>
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bleed2-screenshot.png')">
+			<a href="http://www.bootdiskrevolution.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bleed2-logo.png') center center no-repeat" title="Bleed 2"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PlayStation4, XboxOne</div> -->
+		</div>	
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bleed-screenshot.png')">
+			<a href="http://www.bootdiskrevolution.com/bleed/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bleed-logo.png') center center no-repeat" title="Bleed"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PlayStation4, XboxOne</div> -->
+		</div>	
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/toothandtail-screenshot.png')">
+			<a href="http://www.toothandtailgame.com/" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/toothandtail-logo.png') center center no-repeat" title="Tooth and Tail"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, PlayStation4, Windows</div> -->
+		</div>	
+		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/mgforms-screenshot.png')">
+			<a href="https://github.com/sqrMin1/MonoGame.Forms" >
+			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/mgforms-logo.png') center center no-repeat" title="MonoGame.Forms"></div>
+			</a>
+			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Library, Linux, Windows</div> -->
+		</div>
+</div>

--- a/showcase.md
+++ b/showcase.md
@@ -3,206 +3,181 @@ _title: Showcase
 _description: A list of big hits to small gem titles created using MonoGame.
 ---
 
-There have been 1000s of games, libraries, and tools made using MonoGame over the years.
+<p>There have been 1000s of games, libraries, and tools made using MonoGame over the years.</p>
+<p>We have gathered a taste of those titles here from the big hits to the small hidden gems.</p>
+<p>If you are a developer and would like us to add your game to this list, please submit a GitHub Issue using the <a href = "https://github.com/MonoGame/monogame.github.io/issues/new?assignees=&labels=showcase&projects=&template=01_Showcase_Submission.yml">Showcase Submission template</a></p>
 
-We have gathered a taste of those titles here from the big hits to the small hidden gems.
-
-If you are a developer and would like us to add your game to this list, please submit a GitHub Issue using the Showcase Submission Template [here](https://github.com/MonoGame/monogame.github.io/issues/new?assignees=&labels=showcase&projects=&template=01_Showcase_Submission.yml).
-
-</br>
-</br>
-	<div class="wrap_container" style="width:50%;line-height:0.6cm;">
-		<a href="?">All</a>&nbsp;&nbsp;
-	    <a href="?Featured" >Featured</a>&nbsp;&nbsp;
-		<a href="?Desktop" >Desktop</a>&nbsp;&nbsp;
-		<a href="?Mobile" >Mobile</a>&nbsp;&nbsp;
-		<a href="?Console" >Console</a>&nbsp;&nbsp;
-		<a href="?2D" >2D</a>&nbsp;&nbsp;
-		<a href="?3D" >3D</a>&nbsp;&nbsp;
-		<a href="?Windows" >Windows</a>&nbsp;&nbsp;
-		<a href="?Mac" >Mac</a>&nbsp;&nbsp;
-		<a href="?Linux" >Linux</a>&nbsp;&nbsp;
-		<a href="?iOS" >iOS</a>&nbsp;&nbsp;
-		<a href="?Android" >Android</a>&nbsp;&nbsp;
-		<a href="?WindowsPhone" >WindowsPhone</a>&nbsp;&nbsp;
-		<a href="?NintendoSwitch" >NintendoSwitch</a>&nbsp;&nbsp;
-		<a href="?PlayStation4" >PlayStation4</a>&nbsp;&nbsp;
-		<a href="?XboxOne" >XboxOne</a>&nbsp;&nbsp;
-		<a href="?PSVita" >PSVita</a>&nbsp;&nbsp;
-		<a href="?Library" >Library</a>&nbsp;&nbsp;	
-	</div>
 <br />
-<br />
-<div class="wrap_container">
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/sor4-screenshot.jpg')">
+<div class="wrap-container">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/sor4-screenshot.jpg')">
 		<a href="https://www.streets4rage.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/sor4-logo.png') center center no-repeat" title="Streets of Rage 4"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/paladin-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/paladin-screenshot.jpg')">
 		<a href="http://pumpkin-games.net/paladin.php" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/paladin-logo.png') center center no-repeat" title="Paladin"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, XboxOne</div> -->
 	</div>
-    <div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/fhook-screenshot.png')">
+    <div class="showcase-link-image" style="background-image:url('/images/showcase-header/fhook-screenshot.png')">
 		<a href="http://flinthook.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/fhook-logo.png') center center no-repeat" title="Flinthook"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
 	</div>
-    <div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/mkings-screenshot.png')">
+    <div class="showcase-link-image" style="background-image:url('/images/showcase-header/mkings-screenshot.png')">
 		<a href="http://mercenarykings.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/mkings-logo.png') center center no-repeat" title="Mercenary Kings"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/goat2-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/goat2-screenshot.jpg')">
 		<a href="http://www.escapegoat2.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/goat2-logo.png') center center no-repeat" title="Escape Goat 2"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, PlayStation4</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/daryl-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/daryl-screenshot.jpg')">
 		<a href="https://danandgarygames.com/superdaryldeluxe" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/daryl-logo.png') center center no-repeat" title="Super Daryl Deluxe"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/chasm-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/chasm-screenshot.png')">
 		<a href="http://www.chasmgame.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/chasm-logo.png') center center no-repeat" title="Chasm"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/celeste-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/celeste-screenshot.png')">
 		<a href="http://www.celestegame.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/celeste-logo.png') center center no-repeat" title="Celeste"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/rblob-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/rblob-screenshot.png')">
 		<a href="http://www.rainingblobs.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/rblob-logo.png') center center no-repeat" title="Raining Blobs"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Android, Console, Desktop, Linux, Mac, Mobile, Windows, XboxOne</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/bta-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/bta-screenshot.jpg')">
 		<a href="https://www.eurekaexhibits.com/be-the-astronaut" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/bta-logo.png') center center no-repeat" title="Be the Astronaut"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, 3D, Desktop, Windows</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/armed-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/armed-screenshot.jpg')">
 		<a href="http://www.armedgame.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/armed-logo.png') center center no-repeat" title="ARMED!"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Desktop, Mobile, Windows, WindowsPhone</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/redungeon-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/redungeon-screenshot.png')">
 		<a href="http://www.eneminds.com/redungeon/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/redungeon-logo.png') center center no-repeat" title="Redungeon"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Android, Featured, Mobile, iOS</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/squareheroes-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/squareheroes-screenshot.png')">
 		<a href="http://www.squareheroes.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/squareheroes-logo.png') center center no-repeat" title="Square Heroes"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Console, Featured, PlayStation4</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/wayward-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/wayward-screenshot.jpg')">
 		<a href="http://www.wtfrontier.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/wayward-logo.png') center center no-repeat" title="Wayward Terran Frontier"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Desktop, Featured, Windows</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/bastion-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/bastion-screenshot.jpg')">
 		<a href="http://www.supergiantgames.com/games/bastion/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/bastion-logo.png') center center no-repeat" title="Bastion"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Console, Desktop, Mac, PlayStation4</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/fez-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/fez-screenshot.png')">
 		<a href="http://www.fezgame.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/fez-logo.png') center center no-repeat" title="Fez"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Desktop, Linux, Mac</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/skulls-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/skulls-screenshot.jpg')">
 		<a href="http://skullsoftheshogun.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/skulls-logo.png') center center no-repeat" title="Skulls of the Shogun"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Android, Console, Featured, Mobile, PlayStation4</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/ty-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/ty-screenshot.jpg')">
 		<a href="http://www.kromestudios.com/TY/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/ty-logo.png') center center no-repeat" title="TY the Tasmanian Tiger 4"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Desktop, Featured, Windows</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/oldtimehockey-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/oldtimehockey-screenshot.jpg')">
 		<a href="http://www.bushhockeyleague.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/oth-logo.png') center center no-repeat" title="Bush Hockey League"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Console, Featured, PlayStation4, XboxOne</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/flight-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/flight-screenshot.jpg')">
 		<a href="http://www.infinite-flight.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/flight-logo.png') center center no-repeat" title="Infinite Flight"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Android, Featured, Mobile, iOS</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/neurovoider-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/neurovoider-screenshot.jpg')">
 		<a href="http://www.neurovoider.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/neurovoider-logo.png') center center no-repeat" title="Neurovoider"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, PSVita, PlayStation4, Windows, XboxOne</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/apotheon-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/apotheon-screenshot.jpg')">
 		<a href="http://www.apotheongame.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/apotheon-logo.png') center center no-repeat" title="Apotheon"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, PlayStation4</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/axiom-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/axiom-screenshot.png')">
 		<a href="http://www.axiomverge.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/axiom-logo.png') center center no-repeat" title="Axiom Verge"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/towerfall-screenshot.jpg')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/towerfall-screenshot.jpg')">
 		<a href="http://www.towerfall-game.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/towerfall-logo.png') center center no-repeat" title="Towerfall"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/stardew-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/stardew-screenshot.png')">
 		<a href="http://www.stardewvalley.net/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/stardew-logo4.png') center center no-repeat" title="Stardew Valley"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
 	</div>
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/bleed2-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/bleed2-screenshot.png')">
 		<a href="http://www.bootdiskrevolution.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/bleed2-logo.png') center center no-repeat" title="Bleed 2"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PlayStation4, XboxOne</div> -->
 	</div>	
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/bleed-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/bleed-screenshot.png')">
 		<a href="http://www.bootdiskrevolution.com/bleed/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/bleed-logo.png') center center no-repeat" title="Bleed"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PlayStation4, XboxOne</div> -->
 	</div>	
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/toothandtail-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/toothandtail-screenshot.png')">
 		<a href="http://www.toothandtailgame.com/" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/toothandtail-logo.png') center center no-repeat" title="Tooth and Tail"></div>
 		</a>
 		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, PlayStation4, Windows</div> -->
 	</div>	
-	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/mgforms-screenshot.png')">
+	<div class="showcase-link-image" style="background-image:url('/images/showcase-header/mgforms-screenshot.png')">
 		<a href="https://github.com/sqrMin1/MonoGame.Forms" >
 		<div style="width:100%;height:100%;background:url('/images/showcase-header/mgforms-logo.png') center center no-repeat" title="MonoGame.Forms"></div>
 		</a>

--- a/showcase.md
+++ b/showcase.md
@@ -3,185 +3,209 @@ _title: Showcase
 _description: A list of big hits to small gem titles created using MonoGame.
 ---
 
-There have been 1000s of games, libraries, and tolls made using MonoGame over the years.
+There have been 1000s of games, libraries, and tools made using MonoGame over the years.
 
 We have gathered a taste of those titles here from the big hits to the small hidden gems.
 
-If you are a developer and would like us to add your game to this list, please follow the instructions [here](https://community.monogame.net/t/new-monogame-showcase/10948).
+If you are a developer and would like us to add your game to this list, please submit a GitHub Issue using the Showcase Submission Template [here](https://github.com/MonoGame/monogame.github.io/issues/new?assignees=&labels=showcase&projects=&template=01_Showcase_Submission.yml).
 
-<div style="width:100%;max-width:1110px;margin:0 auto;display:flex;flex-wrap:wrap;justify-center: center;">
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/sor4-screenshot.jpg')">
-			<a href="https://www.streets4rage.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/sor4-logo.png') center center no-repeat" title="Streets of Rage 4"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/paladin-screenshot.jpg')">
-			<a href="http://pumpkin-games.net/paladin.php" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/paladin-logo.png') center center no-repeat" title="Paladin"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, XboxOne</div> -->
-		</div>
-        <div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/fhook-screenshot.png')">
-			<a href="http://flinthook.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/fhook-logo.png') center center no-repeat" title="Flinthook"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
-		</div>
-<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/mkings-screenshot.png')">
-			<a href="http://mercenarykings.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/mkings-logo.png') center center no-repeat" title="Mercenary Kings"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/goat2-screenshot.jpg')">
-			<a href="http://www.escapegoat2.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/goat2-logo.png') center center no-repeat" title="Escape Goat 2"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, PlayStation4</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/daryl-screenshot.jpg')">
-			<a href="https://danandgarygames.com/superdaryldeluxe" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/daryl-logo.png') center center no-repeat" title="Super Daryl Deluxe"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/chasm-screenshot.png')">
-			<a href="http://www.chasmgame.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/chasm-logo.png') center center no-repeat" title="Chasm"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/celeste-screenshot.png')">
-			<a href="http://www.celestegame.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/celeste-logo.png') center center no-repeat" title="Celeste"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/rblob-screenshot.png')">
-			<a href="http://www.rainingblobs.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/rblob-logo.png') center center no-repeat" title="Raining Blobs"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Android, Console, Desktop, Linux, Mac, Mobile, Windows, XboxOne</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bta-screenshot.jpg')">
-			<a href="https://www.eurekaexhibits.com/be-the-astronaut" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bta-logo.png') center center no-repeat" title="Be the Astronaut"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, 3D, Desktop, Windows</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/armed-screenshot.jpg')">
-			<a href="http://www.armedgame.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/armed-logo.png') center center no-repeat" title="ARMED!"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Desktop, Mobile, Windows, WindowsPhone</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/redungeon-screenshot.png')">
-			<a href="http://www.eneminds.com/redungeon/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/redungeon-logo.png') center center no-repeat" title="Redungeon"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Android, Featured, Mobile, iOS</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/squareheroes-screenshot.png')">
-			<a href="http://www.squareheroes.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/squareheroes-logo.png') center center no-repeat" title="Square Heroes"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Console, Featured, PlayStation4</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/wayward-screenshot.jpg')">
-			<a href="http://www.wtfrontier.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/wayward-logo.png') center center no-repeat" title="Wayward Terran Frontier"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Desktop, Featured, Windows</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bastion-screenshot.jpg')">
-			<a href="http://www.supergiantgames.com/games/bastion/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bastion-logo.png') center center no-repeat" title="Bastion"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Console, Desktop, Mac, PlayStation4</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/fez-screenshot.png')">
-			<a href="http://www.fezgame.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/fez-logo.png') center center no-repeat" title="Fez"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Desktop, Linux, Mac</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/skulls-screenshot.jpg')">
-			<a href="http://skullsoftheshogun.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/skulls-logo.png') center center no-repeat" title="Skulls of the Shogun"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Android, Console, Featured, Mobile, PlayStation4</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/ty-screenshot.jpg')">
-			<a href="http://www.kromestudios.com/TY/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/ty-logo.png') center center no-repeat" title="TY the Tasmanian Tiger 4"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Desktop, Featured, Windows</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/oldtimehockey-screenshot.jpg')">
-			<a href="http://www.bushhockeyleague.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/oth-logo.png') center center no-repeat" title="Bush Hockey League"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Console, Featured, PlayStation4, XboxOne</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/flight-screenshot.jpg')">
-			<a href="http://www.infinite-flight.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/flight-logo.png') center center no-repeat" title="Infinite Flight"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Android, Featured, Mobile, iOS</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/neurovoider-screenshot.jpg')">
-			<a href="http://www.neurovoider.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/neurovoider-logo.png') center center no-repeat" title="Neurovoider"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, PSVita, PlayStation4, Windows, XboxOne</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/apotheon-screenshot.jpg')">
-			<a href="http://www.apotheongame.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/apotheon-logo.png') center center no-repeat" title="Apotheon"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, PlayStation4</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/axiom-screenshot.png')">
-			<a href="http://www.axiomverge.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/axiom-logo.png') center center no-repeat" title="Axiom Verge"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/towerfall-screenshot.jpg')">
-			<a href="http://www.towerfall-game.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/towerfall-logo.png') center center no-repeat" title="Towerfall"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/stardew-screenshot.png')">
-			<a href="http://www.stardewvalley.net/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/stardew-logo4.png') center center no-repeat" title="Stardew Valley"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
-		</div>
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bleed2-screenshot.png')">
-			<a href="http://www.bootdiskrevolution.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bleed2-logo.png') center center no-repeat" title="Bleed 2"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PlayStation4, XboxOne</div> -->
-		</div>	
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bleed-screenshot.png')">
-			<a href="http://www.bootdiskrevolution.com/bleed/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/bleed-logo.png') center center no-repeat" title="Bleed"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PlayStation4, XboxOne</div> -->
-		</div>	
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/toothandtail-screenshot.png')">
-			<a href="http://www.toothandtailgame.com/" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/toothandtail-logo.png') center center no-repeat" title="Tooth and Tail"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, PlayStation4, Windows</div> -->
-		</div>	
-		<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/mgforms-screenshot.png')">
-			<a href="https://github.com/sqrMin1/MonoGame.Forms" >
-			<div style="width:100%;height:100%;background:url('https://www.monogame.net/wp-content/themes/monogame/images/showcase-header/mgforms-logo.png') center center no-repeat" title="MonoGame.Forms"></div>
-			</a>
-			<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Library, Linux, Windows</div> -->
-		</div>
-</div>
+</br>
+</br>
+	<div class="wrap_container" style="width:50%;line-height:0.6cm;">
+		<a href="?">All</a>&nbsp;&nbsp;
+	    <a href="?Featured" >Featured</a>&nbsp;&nbsp;
+		<a href="?Desktop" >Desktop</a>&nbsp;&nbsp;
+		<a href="?Mobile" >Mobile</a>&nbsp;&nbsp;
+		<a href="?Console" >Console</a>&nbsp;&nbsp;
+		<a href="?2D" >2D</a>&nbsp;&nbsp;
+		<a href="?3D" >3D</a>&nbsp;&nbsp;
+		<a href="?Windows" >Windows</a>&nbsp;&nbsp;
+		<a href="?Mac" >Mac</a>&nbsp;&nbsp;
+		<a href="?Linux" >Linux</a>&nbsp;&nbsp;
+		<a href="?iOS" >iOS</a>&nbsp;&nbsp;
+		<a href="?Android" >Android</a>&nbsp;&nbsp;
+		<a href="?WindowsPhone" >WindowsPhone</a>&nbsp;&nbsp;
+		<a href="?NintendoSwitch" >NintendoSwitch</a>&nbsp;&nbsp;
+		<a href="?PlayStation4" >PlayStation4</a>&nbsp;&nbsp;
+		<a href="?XboxOne" >XboxOne</a>&nbsp;&nbsp;
+		<a href="?PSVita" >PSVita</a>&nbsp;&nbsp;
+		<a href="?Library" >Library</a>&nbsp;&nbsp;	
+	</div>
+<br />
+<br />
+<div class="wrap_container">
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/sor4-screenshot.jpg')">
+		<a href="https://www.streets4rage.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/sor4-logo.png') center center no-repeat" title="Streets of Rage 4"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/paladin-screenshot.jpg')">
+		<a href="http://pumpkin-games.net/paladin.php" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/paladin-logo.png') center center no-repeat" title="Paladin"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, XboxOne</div> -->
+	</div>
+    <div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/fhook-screenshot.png')">
+		<a href="http://flinthook.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/fhook-logo.png') center center no-repeat" title="Flinthook"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
+	</div>
+    <div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/mkings-screenshot.png')">
+		<a href="http://mercenarykings.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/mkings-logo.png') center center no-repeat" title="Mercenary Kings"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/goat2-screenshot.jpg')">
+		<a href="http://www.escapegoat2.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/goat2-logo.png') center center no-repeat" title="Escape Goat 2"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, PlayStation4</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/daryl-screenshot.jpg')">
+		<a href="https://danandgarygames.com/superdaryldeluxe" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/daryl-logo.png') center center no-repeat" title="Super Daryl Deluxe"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/chasm-screenshot.png')">
+		<a href="http://www.chasmgame.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/chasm-logo.png') center center no-repeat" title="Chasm"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/celeste-screenshot.png')">
+		<a href="http://www.celestegame.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/celeste-logo.png') center center no-repeat" title="Celeste"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PlayStation4, XboxOne</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/rblob-screenshot.png')">
+		<a href="http://www.rainingblobs.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/rblob-logo.png') center center no-repeat" title="Raining Blobs"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Android, Console, Desktop, Linux, Mac, Mobile, Windows, XboxOne</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/bta-screenshot.jpg')">
+		<a href="https://www.eurekaexhibits.com/be-the-astronaut" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/bta-logo.png') center center no-repeat" title="Be the Astronaut"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, 3D, Desktop, Windows</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/armed-screenshot.jpg')">
+		<a href="http://www.armedgame.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/armed-logo.png') center center no-repeat" title="ARMED!"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Desktop, Mobile, Windows, WindowsPhone</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/redungeon-screenshot.png')">
+		<a href="http://www.eneminds.com/redungeon/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/redungeon-logo.png') center center no-repeat" title="Redungeon"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Android, Featured, Mobile, iOS</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/squareheroes-screenshot.png')">
+		<a href="http://www.squareheroes.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/squareheroes-logo.png') center center no-repeat" title="Square Heroes"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Console, Featured, PlayStation4</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/wayward-screenshot.jpg')">
+		<a href="http://www.wtfrontier.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/wayward-logo.png') center center no-repeat" title="Wayward Terran Frontier"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Desktop, Featured, Windows</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/bastion-screenshot.jpg')">
+		<a href="http://www.supergiantgames.com/games/bastion/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/bastion-logo.png') center center no-repeat" title="Bastion"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Console, Desktop, Mac, PlayStation4</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/fez-screenshot.png')">
+		<a href="http://www.fezgame.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/fez-logo.png') center center no-repeat" title="Fez"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Desktop, Linux, Mac</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/skulls-screenshot.jpg')">
+		<a href="http://skullsoftheshogun.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/skulls-logo.png') center center no-repeat" title="Skulls of the Shogun"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Android, Console, Featured, Mobile, PlayStation4</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/ty-screenshot.jpg')">
+		<a href="http://www.kromestudios.com/TY/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/ty-logo.png') center center no-repeat" title="TY the Tasmanian Tiger 4"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Desktop, Featured, Windows</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/oldtimehockey-screenshot.jpg')">
+		<a href="http://www.bushhockeyleague.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/oth-logo.png') center center no-repeat" title="Bush Hockey League"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Console, Featured, PlayStation4, XboxOne</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/flight-screenshot.jpg')">
+		<a href="http://www.infinite-flight.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/flight-logo.png') center center no-repeat" title="Infinite Flight"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">3D, Android, Featured, Mobile, iOS</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/neurovoider-screenshot.jpg')">
+		<a href="http://www.neurovoider.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/neurovoider-logo.png') center center no-repeat" title="Neurovoider"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, PSVita, PlayStation4, Windows, XboxOne</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/apotheon-screenshot.jpg')">
+		<a href="http://www.apotheongame.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/apotheon-logo.png') center center no-repeat" title="Apotheon"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, PlayStation4</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/axiom-screenshot.png')">
+		<a href="http://www.axiomverge.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/axiom-logo.png') center center no-repeat" title="Axiom Verge"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/towerfall-screenshot.jpg')">
+		<a href="http://www.towerfall-game.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/towerfall-logo.png') center center no-repeat" title="Towerfall"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Featured, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/stardew-screenshot.png')">
+		<a href="http://www.stardewvalley.net/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/stardew-logo4.png') center center no-repeat" title="Stardew Valley"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, Linux, Mac, NintendoSwitch, PSVita, PlayStation4, XboxOne</div> -->
+	</div>
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/bleed2-screenshot.png')">
+		<a href="http://www.bootdiskrevolution.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/bleed2-logo.png') center center no-repeat" title="Bleed 2"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PlayStation4, XboxOne</div> -->
+	</div>	
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/bleed-screenshot.png')">
+		<a href="http://www.bootdiskrevolution.com/bleed/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/bleed-logo.png') center center no-repeat" title="Bleed"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, NintendoSwitch, PlayStation4, XboxOne</div> -->
+	</div>	
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/toothandtail-screenshot.png')">
+		<a href="http://www.toothandtailgame.com/" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/toothandtail-logo.png') center center no-repeat" title="Tooth and Tail"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">2D, Console, Desktop, Featured, PlayStation4, Windows</div> -->
+	</div>	
+	<div style="width:333px;height:187px;margin:7px;overflow:hidden;background-size:cover;background-image:url('/images/showcase-header/mgforms-screenshot.png')">
+		<a href="https://github.com/sqrMin1/MonoGame.Forms" >
+		<div style="width:100%;height:100%;background:url('/images/showcase-header/mgforms-logo.png') center center no-repeat" title="MonoGame.Forms"></div>
+		</a>
+		<!-- <div style="position:absolute;bottom:3px;left:3px;font-size:smaller;background-color:#000000;padding:2px;color:#ffffff;">Library, Linux, Windows</div> -->
+	</div>
+</div

--- a/templates/monogame/public/main.css
+++ b/templates/monogame/public/main.css
@@ -43,6 +43,16 @@ article h2
 	max-width: 1152px;
 }
 
+.wrap_container
+{
+  width: 100%;
+  max-width: 1110px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
 .content-center
 {
   text-align: center;

--- a/templates/monogame/public/main.css
+++ b/templates/monogame/public/main.css
@@ -43,7 +43,7 @@ article h2
 	max-width: 1152px;
 }
 
-.wrap_container
+.wrap-container
 {
   width: 100%;
   max-width: 1110px;
@@ -87,6 +87,15 @@ main
 .showcase-feature h4 
 {
   margin-top: 0.9em;
+}
+
+.showcase-link-image
+{
+  width:333px;
+  height:187px;
+  margin:7px;
+  overflow:hidden;
+  background-size:cover;
 }
 
 #big-image-header

--- a/toc.yml
+++ b/toc.yml
@@ -5,7 +5,7 @@
   homepage: api/index.md
 - name: Community
   href: https://community.monogame.net/
-# - name: Showcase
-#  href: showcase.md
+- name: Showcase
+  href: showcase.md
 - name: About
   href: about.md


### PR DESCRIPTION
Enabled showcase.md in toc.yml
Moved the existing showcase games per issue  #3 
Adding some supporting css classes
Changed the link to point to the newly created GitHub issue template instead of the Community post

The existing filtering functionality was not moved over with this. Not sure if that is a deal breaker or if there are new plans to do something different.