### PR TITLE
Add whitespace to game-data.js cleanup urls

### DIFF
--- a/scripts/game-data.js
+++ b/scripts/game-data.js
@@ -1,35 +1,452 @@
 var games = [
-
-    {"name":"sor4","title":"Streets of Rage 4","logo":"sor4-logo.png","screenshot":"sor4-screenshot.jpg","url":"https:\/\/www.streets4rage.com\/","pixelart":false,"tags":["2D","Console","PlayStation4","XboxOne","NintendoSwitch","Featured"]},
-    {"name":"paladin","title":"Paladin","logo":"paladin-logo.png","screenshot":"paladin-screenshot.jpg","url":"http:\/\/pumpkin-games.net\/paladin.php","pixelart":false,"tags":["2D","Console","Mac","Linux","Desktop","XboxOne","NintendoSwitch","Featured"]},
-    {"name":"fhook","title":"Flinthook","logo":"fhook-logo.png","screenshot":"fhook-screenshot.png","url":"http:\/\/flinthook.com\/","pixelart":true,"tags":["2D","Console","PlayStation4","XboxOne","NintendoSwitch","Featured"]},
-    {"name":"mkings","title":"Mercenary Kings","logo":"mkings-logo.png","screenshot":"mkings-screenshot.png","url":"http:\/\/mercenarykings.com\/","pixelart":true,"tags":["2D","Console","PlayStation4","XboxOne","NintendoSwitch","PSVita"]},
-    {"name":"goat2","title":"Escape Goat 2","logo":"goat2-logo.png","screenshot":"goat2-screenshot.jpg","url":"http:\/\/www.escapegoat2.com\/","pixelart":true,"tags":["2D","Console","PlayStation4"]},
-    {"name":"daryl","title":"Super Daryl Deluxe","logo":"daryl-logo.png","screenshot":"daryl-screenshot.jpg","url":"https:\/\/danandgarygames.com\/superdaryldeluxe","pixelart":false,"tags":["2D","Console","PlayStation4","NintendoSwitch","Featured"]},    
-    {"name":"chasm","title":"Chasm","logo":"chasm-logo.png","screenshot":"chasm-screenshot.png","url":"http:\/\/www.chasmgame.com\/","pixelart":true,"tags":["2D","Console","PlayStation4","PSVita","NintendoSwitch","Featured"]},
-    {"name":"celeste","title":"Celeste","logo":"celeste-logo.png","screenshot":"celeste-screenshot.png","url":"http:\/\/www.celestegame.com\/","pixelart":true,"tags":["2D","Console","XboxOne","NintendoSwitch","PlayStation4","Featured"]},
-    {"name":"rblob","title":"Raining Blobs","logo":"rblob-logo.png","screenshot":"rblob-screenshot.png","url":"http:\/\/www.rainingblobs.com\/","pixelart":true,"tags":["2D","Android","Console","Desktop","Linux","Mac","Mobile","Windows","XboxOne"]},
-    {"name":"bta","title":"Be the Astronaut","logo":"bta-logo.png","screenshot":"bta-screenshot.jpg","url":"https:\/\/www.eurekaexhibits.com\/be-the-astronaut","pixelart":false,"tags":["2D","3D","Desktop","Windows"]},
-    {"name":"armed","title":"ARMED!","logo":"armed-logo.png","screenshot":"armed-screenshot.jpg","url":"http:\/\/www.armedgame.com\/","pixelart":false,"tags":["3D","Desktop","Mobile","Windows","WindowsPhone"]},
-    {"name":"redungeon","title":"Redungeon","logo":"redungeon-logo.png","screenshot":"redungeon-screenshot.png","url":"https:\/\/apps.apple.com\/us\/app\/redungeon\/id1119569595","pixelart":true,"tags":["Mobile","iOS","Android","Featured"]},
-    {"name":"squareheroes","title":"Square Heroes","logo":"squareheroes-logo.png","screenshot":"squareheroes-screenshot.png","url":"http:\/\/www.squareheroes.com\/","pixelart":false,"tags":["Console","PlayStation4","Featured"]},
-    {"name":"wayward","title":"Wayward Terran Frontier","logo":"wayward-logo.png","screenshot":"wayward-screenshot.jpg","url":"http:\/\/www.wtfrontier.com\/","pixelart":false,"tags":["Windows","Desktop","Featured"]},
-    {"name":"bastion","title":"Bastion","logo":"bastion-logo.png","screenshot":"bastion-screenshot.jpg","url":"http:\/\/www.supergiantgames.com\/games\/bastion\/","pixelart":false,"tags":["Console","Desktop","Mac","PlayStation4"]},
-    {"name":"fez","title":"Fez","logo":"fez-logo.png","screenshot":"fez-screenshot.png","url":"http:\/\/www.fezgame.com\/","pixelart":true,"tags":["Desktop","Linux","Mac"]},
-    {"name":"skulls","title":"Skulls of the Shogun","logo":"skulls-logo.png","screenshot":"skulls-screenshot.jpg","url":"https:\/\/www.songinthesmoke.com\/skullsoftheshogun","pixelart":false,"tags":["Console","PlayStation4","Mobile","Android","Featured"]},
-    {"name":"ty","title":"TY the Tasmanian Tiger 4","logo":"ty-logo.png","screenshot":"ty-screenshot.jpg","url":"http:\/\/www.kromestudios.com\/TY\/","pixelart":false,"tags":["Desktop","Windows","2D","Featured"]},
-    {"name":"hockey","title":"Bush Hockey League","logo":"oth-logo.png","screenshot":"oldtimehockey-screenshot.jpg","url":"https:\/\/store.steampowered.com\/app\/543010\/Bush_Hockey_League\/","pixelart":false,"tags":["Console","PlayStation4","XboxOne","3D","Featured"]},
-    {"name":"flight","title":"Infinite Flight","logo":"flight-logo.png","screenshot":"flight-screenshot.jpg","url":"http:\/\/www.infinite-flight.com\/","pixelart":false,"tags":["iOS","Android","Mobile","3D","Featured"]},
-    {"name":"neurovoider","title":"Neurovoider","logo":"neurovoider-logo.png","screenshot":"neurovoider-screenshot.jpg","url":"http:\/\/www.neurovoider.com\/","pixelart":true,"tags":["Windows","Mac","Linux","XboxOne","PlayStation4","PSVita","NintendoSwitch","2D","Desktop","Console","Featured"]},
-    {"name":"apotheon","title":"Apotheon","logo":"apotheon-logo.png","screenshot":"apotheon-screenshot.jpg","url":"http:\/\/www.apotheongame.com\/","pixelart":false,"tags":["PlayStation4","2D","Console","Featured"]},
-    {"name":"axiom","title":"Axiom Verge","logo":"axiom-logo.png","screenshot":"axiom-screenshot.png","url":"http:\/\/www.axiomverge.com\/","pixelart":true,"tags":["PlayStation4","XboxOne","NintendoSwitch","PSVita","2D","Console","Featured"]},
-    {"name":"towerfall","title":"Towerfall","logo":"towerfall-logo.png","screenshot":"towerfall-screenshot.jpg","url":"http:\/\/www.towerfall-game.com\/","pixelart":true,"tags":["PlayStation4","XboxOne","NintendoSwitch","PSVita","2D","Console","Featured"]},
-    {"name":"stardew","title":"Stardew Valley","logo":"stardew-logo4.png","screenshot":"stardew-screenshot.png","url":"http:\/\/www.stardewvalley.net\/","pixelart":true,"tags":["PlayStation4","XboxOne","NintendoSwitch","PSVita","2D","Console","Mac","Linux","Desktop","Featured"]},
-    {"name":"bleed2","title":"Bleed 2","logo":"bleed2-logo.png","screenshot":"bleed2-screenshot.png","url":"http:\/\/www.bootdiskrevolution.com\/","pixelart":true,"tags":["2D","Console","NintendoSwitch","PlayStation4","XboxOne"]},
-    {"name":"bleed","title":"Bleed","logo":"bleed-logo.png","screenshot":"bleed-screenshot.png","url":"http:\/\/www.bootdiskrevolution.com\/bleed\/","pixelart":true,"tags":["2D","Console","NintendoSwitch","PlayStation4","XboxOne"]},
-    {"name":"toothandtail","title":"Tooth and Tail","logo":"toothandtail-logo.png","screenshot":"toothandtail-screenshot.png","url":"http:\/\/www.toothandtailgame.com\/","pixelart":false,"tags":["PlayStation4","Windows","2D","Console","Desktop","Featured"]},
-    {"name":"mgforms","title":"MonoGame.Forms","logo":"mgforms-logo.png","screenshot":"mgforms-screenshot.png","url":"https:\/\/github.com\/sqrMin1\/MonoGame.Forms","pixelart":false,"tags":["Library","Linux","Windows"]}
-
+    {
+        "name": "sor4",
+        "title": "Streets of Rage 4",
+        "logo": "sor4-logo.png",
+        "screenshot": "sor4-screenshot.jpg",
+        "url": "https://www.streets4rage.com/",
+        "pixelart": false,
+        "tags": [
+            "2D",
+            "Console",
+            "PlayStation4",
+            "XboxOne",
+            "NintendoSwitch",
+            "Featured"
+        ]
+    },
+    {
+        "name": "paladin",
+        "title": "Paladin",
+        "logo": "paladin-logo.png",
+        "screenshot": "paladin-screenshot.jpg",
+        "url": "http://pumpkin-games.net/paladin.php",
+        "pixelart": false,
+        "tags": [
+            "2D",
+            "Console",
+            "Mac",
+            "Linux",
+            "Desktop",
+            "XboxOne",
+            "NintendoSwitch",
+            "Featured"
+        ]
+    },
+    {
+        "name": "fhook",
+        "title": "Flinthook",
+        "logo": "fhook-logo.png",
+        "screenshot": "fhook-screenshot.png",
+        "url": "http://flinthook.com/",
+        "pixelart": true,
+        "tags": [
+            "2D",
+            "Console",
+            "PlayStation4",
+            "XboxOne",
+            "NintendoSwitch",
+            "Featured"
+        ]
+    },
+    {
+        "name": "mkings",
+        "title": "Mercenary Kings",
+        "logo": "mkings-logo.png",
+        "screenshot": "mkings-screenshot.png",
+        "url": "http://mercenarykings.com/",
+        "pixelart": true,
+        "tags": [
+            "2D",
+            "Console",
+            "PlayStation4",
+            "XboxOne",
+            "NintendoSwitch",
+            "PSVita"
+        ]
+    },
+    {
+        "name": "goat2",
+        "title": "Escape Goat 2",
+        "logo": "goat2-logo.png",
+        "screenshot": "goat2-screenshot.jpg",
+        "url": "http://www.escapegoat2.com/",
+        "pixelart": true,
+        "tags": [
+            "2D",
+            "Console",
+            "PlayStation4"
+        ]
+    },
+    {
+        "name": "daryl",
+        "title": "Super Daryl Deluxe",
+        "logo": "daryl-logo.png",
+        "screenshot": "daryl-screenshot.jpg",
+        "url": "https://danandgarygames.com/superdaryldeluxe",
+        "pixelart": false,
+        "tags": [
+            "2D",
+            "Console",
+            "PlayStation4",
+            "NintendoSwitch",
+            "Featured"
+        ]
+    },
+    {
+        "name": "chasm",
+        "title": "Chasm",
+        "logo": "chasm-logo.png",
+        "screenshot": "chasm-screenshot.png",
+        "url": "http://www.chasmgame.com/",
+        "pixelart": true,
+        "tags": [
+            "2D",
+            "Console",
+            "PlayStation4",
+            "PSVita",
+            "NintendoSwitch",
+            "Featured"
+        ]
+    },
+    {
+        "name": "celeste",
+        "title": "Celeste",
+        "logo": "celeste-logo.png",
+        "screenshot": "celeste-screenshot.png",
+        "url": "http://www.celestegame.com/",
+        "pixelart": true,
+        "tags": [
+            "2D",
+            "Console",
+            "XboxOne",
+            "NintendoSwitch",
+            "PlayStation4",
+            "Featured"
+        ]
+    },
+    {
+        "name": "rblob",
+        "title": "Raining Blobs",
+        "logo": "rblob-logo.png",
+        "screenshot": "rblob-screenshot.png",
+        "url": "http://www.rainingblobs.com/",
+        "pixelart": true,
+        "tags": [
+            "2D",
+            "Android",
+            "Console",
+            "Desktop",
+            "Linux",
+            "Mac",
+            "Mobile",
+            "Windows",
+            "XboxOne"
+        ]
+    },
+    {
+        "name": "bta",
+        "title": "Be the Astronaut",
+        "logo": "bta-logo.png",
+        "screenshot": "bta-screenshot.jpg",
+        "url": "https://www.eurekaexhibits.com/be-the-astronaut",
+        "pixelart": false,
+        "tags": [
+            "2D",
+            "3D",
+            "Desktop",
+            "Windows"
+        ]
+    },
+    {
+        "name": "armed",
+        "title": "ARMED!",
+        "logo": "armed-logo.png",
+        "screenshot": "armed-screenshot.jpg",
+        "url": "http://www.armedgame.com/",
+        "pixelart": false,
+        "tags": [
+            "3D",
+            "Desktop",
+            "Mobile",
+            "Windows",
+            "WindowsPhone"
+        ]
+    },
+    {
+        "name": "redungeon",
+        "title": "Redungeon",
+        "logo": "redungeon-logo.png",
+        "screenshot": "redungeon-screenshot.png",
+        "url": "https://apps.apple.com/us/app/redungeon/id1119569595",
+        "pixelart": true,
+        "tags": [
+            "Mobile",
+            "iOS",
+            "Android",
+            "Featured"
+        ]
+    },
+    {
+        "name": "squareheroes",
+        "title": "Square Heroes",
+        "logo": "squareheroes-logo.png",
+        "screenshot": "squareheroes-screenshot.png",
+        "url": "http://www.squareheroes.com/",
+        "pixelart": false,
+        "tags": [
+            "Console",
+            "PlayStation4",
+            "Featured"
+        ]
+    },
+    {
+        "name": "wayward",
+        "title": "Wayward Terran Frontier",
+        "logo": "wayward-logo.png",
+        "screenshot": "wayward-screenshot.jpg",
+        "url": "http://www.wtfrontier.com/",
+        "pixelart": false,
+        "tags": [
+            "Windows",
+            "Desktop",
+            "Featured"
+        ]
+    },
+    {
+        "name": "bastion",
+        "title": "Bastion",
+        "logo": "bastion-logo.png",
+        "screenshot": "bastion-screenshot.jpg",
+        "url": "http://www.supergiantgames.com/games/bastion/",
+        "pixelart": false,
+        "tags": [
+            "Console",
+            "Desktop",
+            "Mac",
+            "PlayStation4"
+        ]
+    },
+    {
+        "name": "fez",
+        "title": "Fez",
+        "logo": "fez-logo.png",
+        "screenshot": "fez-screenshot.png",
+        "url": "http://www.fezgame.com/",
+        "pixelart": true,
+        "tags": [
+            "Desktop",
+            "Linux",
+            "Mac"
+        ]
+    },
+    {
+        "name": "skulls",
+        "title": "Skulls of the Shogun",
+        "logo": "skulls-logo.png",
+        "screenshot": "skulls-screenshot.jpg",
+        "url": "https://www.songinthesmoke.com/skullsoftheshogun",
+        "pixelart": false,
+        "tags": [
+            "Console",
+            "PlayStation4",
+            "Mobile",
+            "Android",
+            "Featured"
+        ]
+    },
+    {
+        "name": "ty",
+        "title": "TY the Tasmanian Tiger 4",
+        "logo": "ty-logo.png",
+        "screenshot": "ty-screenshot.jpg",
+        "url": "http://www.kromestudios.com/TY/",
+        "pixelart": false,
+        "tags": [
+            "Desktop",
+            "Windows",
+            "2D",
+            "Featured"
+        ]
+    },
+    {
+        "name": "hockey",
+        "title": "Bush Hockey League",
+        "logo": "oth-logo.png",
+        "screenshot": "oldtimehockey-screenshot.jpg",
+        "url": "https://store.steampowered.com/app/543010/Bush_Hockey_League/",
+        "pixelart": false,
+        "tags": [
+            "Console",
+            "PlayStation4",
+            "XboxOne",
+            "3D",
+            "Featured"
+        ]
+    },
+    {
+        "name": "flight",
+        "title": "Infinite Flight",
+        "logo": "flight-logo.png",
+        "screenshot": "flight-screenshot.jpg",
+        "url": "http://www.infinite-flight.com/",
+        "pixelart": false,
+        "tags": [
+            "iOS",
+            "Android",
+            "Mobile",
+            "3D",
+            "Featured"
+        ]
+    },
+    {
+        "name": "neurovoider",
+        "title": "Neurovoider",
+        "logo": "neurovoider-logo.png",
+        "screenshot": "neurovoider-screenshot.jpg",
+        "url": "http://www.neurovoider.com/",
+        "pixelart": true,
+        "tags": [
+            "Windows",
+            "Mac",
+            "Linux",
+            "XboxOne",
+            "PlayStation4",
+            "PSVita",
+            "NintendoSwitch",
+            "2D",
+            "Desktop",
+            "Console",
+            "Featured"
+        ]
+    },
+    {
+        "name": "apotheon",
+        "title": "Apotheon",
+        "logo": "apotheon-logo.png",
+        "screenshot": "apotheon-screenshot.jpg",
+        "url": "http://www.apotheongame.com/",
+        "pixelart": false,
+        "tags": [
+            "PlayStation4",
+            "2D",
+            "Console",
+            "Featured"
+        ]
+    },
+    {
+        "name": "axiom",
+        "title": "Axiom Verge",
+        "logo": "axiom-logo.png",
+        "screenshot": "axiom-screenshot.png",
+        "url": "http://www.axiomverge.com/",
+        "pixelart": true,
+        "tags": [
+            "PlayStation4",
+            "XboxOne",
+            "NintendoSwitch",
+            "PSVita",
+            "2D",
+            "Console",
+            "Featured"
+        ]
+    },
+    {
+        "name": "towerfall",
+        "title": "Towerfall",
+        "logo": "towerfall-logo.png",
+        "screenshot": "towerfall-screenshot.jpg",
+        "url": "http://www.towerfall-game.com/",
+        "pixelart": true,
+        "tags": [
+            "PlayStation4",
+            "XboxOne",
+            "NintendoSwitch",
+            "PSVita",
+            "2D",
+            "Console",
+            "Featured"
+        ]
+    },
+    {
+        "name": "stardew",
+        "title": "Stardew Valley",
+        "logo": "stardew-logo4.png",
+        "screenshot": "stardew-screenshot.png",
+        "url": "http://www.stardewvalley.net/",
+        "pixelart": true,
+        "tags": [
+            "PlayStation4",
+            "XboxOne",
+            "NintendoSwitch",
+            "PSVita",
+            "2D",
+            "Console",
+            "Mac",
+            "Linux",
+            "Desktop",
+            "Featured"
+        ]
+    },
+    {
+        "name": "bleed2",
+        "title": "Bleed 2",
+        "logo": "bleed2-logo.png",
+        "screenshot": "bleed2-screenshot.png",
+        "url": "http://www.bootdiskrevolution.com/",
+        "pixelart": true,
+        "tags": [
+            "2D",
+            "Console",
+            "NintendoSwitch",
+            "PlayStation4",
+            "XboxOne"
+        ]
+    },
+    {
+        "name": "bleed",
+        "title": "Bleed",
+        "logo": "bleed-logo.png",
+        "screenshot": "bleed-screenshot.png",
+        "url": "http://www.bootdiskrevolution.com/bleed/",
+        "pixelart": true,
+        "tags": [
+            "2D",
+            "Console",
+            "NintendoSwitch",
+            "PlayStation4",
+            "XboxOne"
+        ]
+    },
+    {
+        "name": "toothandtail",
+        "title": "Tooth and Tail",
+        "logo": "toothandtail-logo.png",
+        "screenshot": "toothandtail-screenshot.png",
+        "url": "http://www.toothandtailgame.com/",
+        "pixelart": false,
+        "tags": [
+            "PlayStation4",
+            "Windows",
+            "2D",
+            "Console",
+            "Desktop",
+            "Featured"
+        ]
+    },
+    {
+        "name": "mgforms",
+        "title": "MonoGame.Forms",
+        "logo": "mgforms-logo.png",
+        "screenshot": "mgforms-screenshot.png",
+        "url": "https://github.com/sqrMin1/MonoGame.Forms",
+        "pixelart": false,
+        "tags": [
+            "Library",
+            "Linux",
+            "Windows"
+        ]
+    }
 ];
 
 var BannerPath = "/images/showcase-header/";


### PR DESCRIPTION
Update for #25 .

Beautified the JSON so it has more whitespace and is easier to read.

Cleaned up the escaping \s in the Url fields. Most modern browsers  (Chrome, Firefox, Safari, Edge,) and javascript engines are fine with / now. I tested with a few of these.

Previously this was common practice to avoid script tag injections in html. However, the modern browsers and web standards have other means of prevention. So just having the Urls in the JSON should work fine unless someone is aware of a browser specific issue.