### PR TITLE
Use Discorse API endpoint

### DIFF
--- a/scripts/latest-posts.js
+++ b/scripts/latest-posts.js
@@ -11,7 +11,7 @@ async function initialize_community_feeds() {
  * it into the #latest-community element on the page
  */
 async function get_latest_news() {
-    let response = await fetch('https://communityapi.aristurtle.net/latest-news');
+    let response = await fetch('https://community.monogame.net/latest-news');
     let json = await response.json();
 
     if (json.topic_list.topics != undefined) {
@@ -32,7 +32,7 @@ async function get_latest_news() {
  * it into the #latest-community element on the page
  */
 async function get_latest_community() {
-    let response = await fetch('https://communityapi.aristurtle.net/latest-community');
+    let response = await fetch('https://community.monogame.net/latest-community');
     let json = await response.json();
 
     if (json.topic_list.topics != undefined) {

--- a/scripts/latest-posts.js
+++ b/scripts/latest-posts.js
@@ -11,7 +11,7 @@ async function initialize_community_feeds() {
  * it into the #latest-community element on the page
  */
 async function get_latest_news() {
-    let response = await fetch('https://community.monogame.net/latest-news');
+    let response = await fetch('https://community.monogame.net/latest.json?category=news&order=created');
     let json = await response.json();
 
     if (json.topic_list.topics != undefined) {
@@ -32,7 +32,7 @@ async function get_latest_news() {
  * it into the #latest-community element on the page
  */
 async function get_latest_community() {
-    let response = await fetch('https://community.monogame.net/latest-community');
+    let response = await fetch('https://community.monogame.net/latest.json?order=created');
     let json = await response.json();
 
     if (json.topic_list.topics != undefined) {


### PR DESCRIPTION
The previous PR updated the URL to use to fetch the latest news feeds, but the endpoints were not updated to the discourse endpoints.