### PR TITLE
Removed duplicate game-banner.js script

### DIFF
--- a/index.md
+++ b/index.md
@@ -192,7 +192,6 @@ _overrideDocFx: true
 </section>
 
 <script src="/scripts/game-data.js"></script>
-<script src="/scripts/game-banners.js"></script>
 <script type="text/javascript" src="/scripts/latest-posts.js"></script>
 <script type="text/javascript" src="/scripts/game-banners.js"></script>
 


### PR DESCRIPTION
Duplicate script loading was causing issue where some banner images would only show for a second before changing.