### PR TITLE
Created a redirect from /showcase/ to /showcase

### DIFF
--- a/showcase/index.md
+++ b/showcase/index.md
@@ -1,0 +1,3 @@
+---
+redirect_url: ../showcase
+---


### PR DESCRIPTION
The microsoft page on [Game Engines](https://dotnet.microsoft.com/en-us/apps/games/engines) built with MS tech contains a broken link to the new monogame [showcase page](https://monogame.net/showcase/).

The issue is with the trailing `/` in the url.

This PR adds a page at `/showcase/` that performs a client-side redirect to the correct route `/showcase`.

TimerBaevRR originally reported this on the MonoGame Discord:  https://discord.com/channels/355231098122272778/1175143217403019365/1183688201051832320