### PR TITLE
Fixed community link in footer

### DIFF
--- a/_includes/partials/_footer.njk
+++ b/_includes/partials/_footer.njk
@@ -48,7 +48,7 @@
                         <a href="/blog/" class="p-0">Blog</a>
                     </li>
                     <li class="nav-item mb-2">
-                        <a href="/community/" class="p-0">Community</a>
+                        <a href="https://community.monogame.net" class="p-0">Community</a>
                     </li>
                     <li class="nav-item mb-2">
                         <a href="/presskit/" class="p-0">Press Kit</a>


### PR DESCRIPTION
Was using site relative path, but community site is hosted at a different subdomain