### PR TITLE
Remove `theme` meta tag

### DIFF
--- a/_includes/partials/_head.njk
+++ b/_includes/partials/_head.njk
@@ -2,7 +2,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 <meta name="title" content="{{ title if title else site.meta.title }} | {{ site.name }}"/>
 <meta name="description" content="{{ description if description else site.meta.description }}"/>
-<meta name="theme-color" content="{{ site.meta.themeColor }}" />
 
 {# HTMl Meta Tags #}
 <title>{{ title if title else site.meta.title }} | {{site.name }}</title>


### PR DESCRIPTION
This is causing an overwhelming amount of orange in for safari users.  Will need to look into adding it back for social embeds without affecting scrollbars and title window for safari

![image](https://github.com/MonoGame/monogame.github.io/assets/103014489/9e8972dd-2c73-4737-aadf-440e5490c47c)

(screenshot taken from @harry-cpp )