### PR TITLE
Adds an Atom/RSS Feed For Blog

### DIFF
--- a/.config/eleventy.config.plugins.js
+++ b/.config/eleventy.config.plugins.js
@@ -2,6 +2,7 @@
 const navigation = require('@11ty/eleventy-navigation');
 const syntaxhighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 const nesting = require('eleventy-plugin-nesting-toc');
+const feed = require('@11ty/eleventy-plugin-rss');
 const { EleventyHtmlBasePlugin } = require('@11ty/eleventy');
 
 
@@ -17,4 +18,5 @@ module.exports = function (config) {
         headingTag: 'h5'
     });
     config.addPlugin(EleventyHtmlBasePlugin);
+    config.addPlugin(feed);
 }

--- a/_data/site.json
+++ b/_data/site.json
@@ -75,6 +75,11 @@
             "title": "Twitter",
             "url": "https://twitter.com/MonoGameTeam",
             "icon": "bi-twitter"
+        },
+        {
+            "title": "Blog RSS Feed",
+            "url": "https://monogame.net/blog/feed.xml",
+            "icon": "bi-rss-fill"
         }
     ]
 }

--- a/content/blog/feed.njk
+++ b/content/blog/feed.njk
@@ -22,7 +22,7 @@ eleventyExcludeFromCollections: true
             <link href="{{ absolutePostUrl }}"/>
             <updated>{{ post.date | dateToRfc3339 }}</updated>
             <id>{{ absolutePostUrl }}</id>
-            <content xml:lang="{{ metadata.language }}" type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+            <content xml:lang="en-US" type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
         </entry>
     {%- endfor %}
 </feed>

--- a/content/blog/feed.njk
+++ b/content/blog/feed.njk
@@ -1,0 +1,28 @@
+---
+layout: ''
+permalink: "blog/feed.xml"
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:base="{{ site.hostname }}">
+    <title>{{ site.meta.title }}</title>
+    <subtitle>{{ site.meta.description }}</subtitle>
+    <link href="{{ permalink | absoluteUrl(site.hostname) }}" rel="self"/>
+    <link href="{{ site.hostname }}"/>
+    <updated>{{ collections.blogPosts | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
+    <id>{{ site.hostname }}/</id>
+    <author>
+        <name>MonoGame Foundation</name>
+        <email>admin@monogame.net</email>
+    </author>
+    {%- for post in collections.blogPosts | reverse %}
+        {%- set absolutePostUrl = post.url | absoluteUrl(site.hostname) %}
+        <entry>
+            <title>{{ post.data.title }}</title>
+            <link href="{{ absolutePostUrl }}"/>
+            <updated>{{ post.date | dateToRfc3339 }}</updated>
+            <id>{{ absolutePostUrl }}</id>
+            <content xml:lang="{{ metadata.language }}" type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+        </entry>
+    {%- endfor %}
+</feed>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "monogame.github.io",
+    "name": "aristurtle.monogame.github.io",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -7,6 +7,7 @@
             "devDependencies": {
                 "@11ty/eleventy": "^2.0.1",
                 "@11ty/eleventy-navigation": "^0.3.5",
+                "@11ty/eleventy-plugin-rss": "^1.2.0",
                 "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
                 "bootstrap": "^5.3.2",
                 "bootstrap-icons": "^1.11.2",
@@ -114,6 +115,21 @@
             "dev": true,
             "dependencies": {
                 "dependency-graph": "^0.11.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/11ty"
+            }
+        },
+        "node_modules/@11ty/eleventy-plugin-rss": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.2.0.tgz",
+            "integrity": "sha512-YzFnSH/5pObcFnqZ2sAQ782WmpOZHj1+xB9ydY/0j7BZ2jUNahn53VmwCB/sBRwXA/Fbwwj90q1MLo01Ru0UaQ==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.3.4",
+                "posthtml": "^0.16.6",
+                "posthtml-urls": "1.0.0"
             },
             "funding": {
                 "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
         "@11ty/eleventy-navigation": "^0.3.5",
+        "@11ty/eleventy-plugin-rss": "^1.2.0",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
         "bootstrap": "^5.3.2",
         "bootstrap-icons": "^1.11.2",


### PR DESCRIPTION
## Description
This pull request adds an Atom/RSS feed for the blog page so that users can subscribe to it to receive updates in whatever reader they use when news is posted.  It makes uses of the official 11ty RSS plugin and delivers the feed at the url `https://monogame.net/blog/feed.xml`

## Motivation
I was approached by a community member in discord about adding an RSS feed to the blog. Adding an RSS feed is minimal work and requires no maintenance, it will update itself automatically every time the site is published with changes.