### PR TITLE
Fixes blog foundation link on bounty page

### DIFF
--- a/content/bounties.njk
+++ b/content/bounties.njk
@@ -26,7 +26,7 @@ description: The MonoGame Foundation uses a bounty system to propose paid incent
 		<p>
             The Foundation board will review your application during the next board meeting (happening every second Wednesday of
 			each month; and providing that you sent your application at least 48 hours ahead of the next meeting). The board will
-			then let you know of the decision. The decision will also be made public in the <a href="blog/foundation/">meeting's minutes</a>.
+			then let you know of the decision. The decision will also be made public in the <a href="/blog/foundation/">meeting's minutes</a>.
 			If the decision is favorable, a service agreement will be proposed to you to legally bind both parties.
         </p>
 		<p>


### PR DESCRIPTION
## Description
Link to to the foundation blog category needed a preceding `/` to make the path absolute to the domain and not relative to the page.