### PR TITLE
Adds atom/rss feed meta link in page header

### DIFF
--- a/_includes/partials/_head.njk
+++ b/_includes/partials/_head.njk
@@ -24,6 +24,9 @@
 {# Favicon #}
 <link rel="icon" href="{{ site.hostname }}{{ favicon if favicon else site.favicon }}"/>
 
+{# Atom/Rss feed autodiscovery #}
+<link rel="alternate" type="application/atom+xml" title="MonoGame Blog"  href="/blog/feed.xml" />
+
 {# Styles #}
 <link rel="stylesheet" href="/bundle.css"/>
 


### PR DESCRIPTION
## Description
This adds the following meta tag to the `<head>` section of each page
```
<link rel="alternate" type="application/atom+xml" title="MonoGame Blog"  href="/blog/feed.xml" />
```

## Motivation
With the recent atom/rss feed that was added for the blog page, having this tag in the header will allow browsers and extensions that automatically pickup feeds to see it an let the user know there is a feed they can subscribe too.