### PR TITLE
Add Redirect Feature

### DIFF
--- a/.config/collections/redirect.js
+++ b/.config/collections/redirect.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const redirects = new Set();
+
+/** @param {import("@11ty/eleventy/src/TemplateCollection")} api */
+function redirect(api) {
+    //  Add any manual redirects needed in the future here manually
+    //  Example:
+    //      redirects.add({from: "old/path", to: "new/path"});
+
+    //--------------------------------------------------------------------------
+    //  Warning:
+    //
+    //  Do not edit below unless you are aware of what you are doing.
+    //  The following is an automation that creates redirects for all article
+    //  files since the URLs have changed on them once we moved to 11ty.
+    //
+    //  For example
+    // '/articles/packaging_games.html' changed to '/articles/packaging_game/'
+    //
+    //--------------------------------------------------------------------------
+    api.getFilteredByGlob('./content/articles/**/*.md')
+       .forEach( (article) => {
+        let path = article.page.url;
+        let from = path.slice(0, -1) + '.html'
+        redirects.add({from: from, to: path});
+       });
+
+    return Array.from(redirects);
+}
+
+module.exports = redirect;

--- a/.config/eleventy.config.collections.js
+++ b/.config/eleventy.config.collections.js
@@ -5,6 +5,7 @@ const blogTags = require('./collections/blogTags');
 const gameTags = require('./collections/gameTags');
 const apiToc = require('./collections/apiToc');
 const articlesToc = require('./collections/articlesToc');
+const redirect = require('./collections/redirect');
 
 
 /** @param {import("@11ty/eleventy").UserConfig} config */
@@ -14,4 +15,5 @@ module.exports = function (config) {
     config.addCollection('gameTags', gameTags);
     config.addCollection('apiToc', apiToc);
     config.addCollection('articlesToc', articlesToc);
+    config.addCollection('redirects', redirect);
 }

--- a/_includes/layouts/redirect.layout.njk
+++ b/_includes/layouts/redirect.layout.njk
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <meta charset="utf-8"/>
+    <title>Redirecting&hellip;</title>
+    <link rel="canonical" href="{{ redirect.to | url }}"/>
+    <script>
+        location = '{{ redirect.to | url }}';
+    </script>
+    <meta http-equiv="refresh" content="0; url={{ redirect.to | url }}"/>
+    <meta name="robots" content="noindex"/>
+    <h1>Redirecting&hellip;</h1>
+    <a href="{{ redirect.to | url }}">Click here if you are not redirected.</a>
+</html>

--- a/content/redirects.md
+++ b/content/redirects.md
@@ -1,0 +1,10 @@
+---
+pagination:
+    data: redirects
+    size: 1
+    alias: redirect
+redirects:
+    - {"from": "/articles/packaging_games.html", "to": "/articles/packaging_games/" }
+permalink: "{{ redirect.from }}"
+layout: "layouts/redirect.layout.njk"
+---

--- a/content/redirects.md
+++ b/content/redirects.md
@@ -1,10 +1,8 @@
 ---
 pagination:
-    data: redirects
+    data: collections.redirects
     size: 1
     alias: redirect
-redirects:
-    - {"from": "/articles/packaging_games.html", "to": "/articles/packaging_games/" }
 permalink: "{{ redirect.from }}"
 layout: "layouts/redirect.layout.njk"
 ---


### PR DESCRIPTION
## Description
This adds redirect functionality to the website through the following
- A new collection called `redirects` has been created.  The data for this collection is generated by the `.config/collections/redirect.js` module.  In here, you can manually add redirects if needed for any future reasons.
    - This includes a section with a clear warning not to adjust the code.  This section will generate redirections for all `/article/**/*.md` documents so that the old style links will redirect to the new style links and SEO isn't lost.
- `_includes/layouts/redirect.layout.njk`
    - Simple redirect HTML page that uses the `<meta>` refresh method to redirect the user to the correct url.  
    - Includes `<meta name="robots" content="noindex""/>` tag for robots/crawlers to inform them to **not** index the old page
    - Includes `<link rel="canonical">` tag which informs search engines such as Google that the `href` being redirected to should be the canonical url for that page so that search engines will update over time.
- `content/redirects.md`
    - Markdown file that contains only the YAML frontmatter and uses the 11ty pagination feature
    - Uses the `permalink` frontmatter to specify where the redirect page will be output to which is the old page url.

With these files, when the site is built, the `redirects` collection is autogenerated and handled by the**contents/redirect.md**` file to generate the individual redirect pages for all urls that require redirects. 

## Note
Typically for redirects you would want the HTTP Response to be an HTTP 301: Permanent Redirect response.  However, since this is a static website served from GitHub pages, we don't have control over the HTTP response that is sent, so this is the closest we can get to redirecting while also including tags to tell search engines to update over time.

## Related Issues
This is a feature implementation for Issue #78 