### PR TITLE
Bump docfx version to fix api doc issue

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.74.1",
+      "version": "2.75.2",
       "commands": [
         "docfx"
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "aristurtle.monogame.github.io",
+    "name": "monogame.github.io",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
This is in regards to issue #58 

A new docfx version with the fix for their issue [9618](https://github.com/dotnet/docfx/issues/9618) (as reported by Aristurtle, thank you!) has been released. 

In my test app the Ubuntu runner was able to produce the 460ish api docs when using the newest version of docfx. 