### PR TITLE
Update dotnet version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,12 +21,7 @@ jobs:
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
-
-      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Restore NPM Packages
         run: npm install


### PR DESCRIPTION
We need to upgrade the .NET version now that we upgraded MonoGame.

@AristurtleDev Do we still need v6 or v7? It seems that docfx should work on .NET 8 too and we only need that version.