### PR TITLE
[Documentation] Fix instructions for installing MonoGame Templates

### DIFF
--- a/documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
+++ b/documentation/articles/getting_started/1_setting_up_your_development_environment_windows.md
@@ -64,7 +64,7 @@ If you prefer to use JetBrains Rider or Visual Studio Code, and after installing
 Once the .NET 6 SDK is installed, you can open a Command Prompt and install the MonoGame templates by typing the following command:
 
 ```sh
-dotnet new install MonoGame.Templates.CSharp
+dotnet new --install MonoGame.Templates.CSharp
 ```
 
 **Next up:** [Creating a new project](2_creating_a_new_project_vs.md)


### PR DESCRIPTION
This is a documentation fix for the Getting Started guide on the website.
https://monogame.net/articles/getting_started/1_setting_up_your_development_environment_windows.html

**Issue:**  
The command in the Getting Started section for installing MonoGame templates for .NET does not work.
```sh
dotnet new install MonoGame.Templates.CSharp
```

Instead it has to be:
```sh
dotnet new --install MonoGame.Templates.CSharp
```

The latter is consistent with other places in the documentation and allowed me to install MonoGame and use it in Jetbrains Rider.