### PR TITLE
Added `requireMSLicense` Frontmatter Tag

### DIFF
--- a/documentation/templates/monogame/layout/_master.tmpl
+++ b/documentation/templates/monogame/layout/_master.tmpl
@@ -44,6 +44,11 @@
 
         <article data-uid="{{uid}}">
           {{!body}}
+          {{#requireMSLicense}}
+            <div class="d-flex flex-row justify-content-end">
+                <i>© 2012 Microsoft Corporation. All rights reserved.</i>
+            </div>
+          {{/requireMSLicense}}
         </article>
 
         {{^_disableContribution}}


### PR DESCRIPTION
## Description
This PR adds functionality for a new frontmatter tag called `requireMSLicense`.  By supplying this tag in a document and setting it to `true`, then the article will inject the following copyright statement at the end of the article, right-justified, and in italics

```
© 2012 Microsoft Corporation. All rights reserved.
```
## Reference
[Issue #115: Feature Request: Add new Frontmatter tag to append the MS license to docs migrated from Microsoft ](https://github.com/MonoGame/monogame.github.io/issues/115)