### PR TITLE
Auto Title And Description

### DIFF
--- a/documentation/templates/monogame/conceptual.extension.js
+++ b/documentation/templates/monogame/conceptual.extension.js
@@ -1,0 +1,37 @@
+/**
+ * This method will be called at the start of exports.transform in conceptual.html.primary.js
+ */
+exports.preTransform = function (model) {
+    return model;
+}
+
+/**
+ * This method will be called at the end of exports.transform in conceptual.html.primary.js
+ */
+exports.postTransform = function (model) {
+    model.title = model.title ?? getTitle(model);
+    model.description = model.description ?? getDescription(model);
+    return model;
+}
+
+function getTitle(model) {
+    //  model.rawTitle is the full contents of the first <h1> tag on the page.
+    //  So just remove the HTML tag info and take the innerText for the title.
+    return model.rawTitle.replace(/<.*?>/g, '').trim();
+}
+
+function getDescription(model) {
+    //  model.conceptual contains the conceptual generated HTML for the page.
+    //  Locate the first p tag opening and the first </p> tag close after that
+    //  then capture the substring using those indexes, then remove the HTML tag
+    //  info to get the innerText as the description.
+    const pOpen = model.conceptual.indexOf('<p');
+    const pClose = model.conceptual.indexOf('</p>', pOpen);
+
+    if (pOpen != -1 && pClose != -1) {
+        const p = model.conceptual.substring(pOpen, pClose + 4);
+        return p.replace(/<.*?>/g, '').trim();
+    }
+
+    return '';
+}


### PR DESCRIPTION
## Description
This PR adds functionality that will automatically generate the frontmatter `title` and `description` values on a page.  The `title` is generated from the first heading section on the page and the `description` is generated from the first paragraph on the page.

For example

```md
# Setting up your development environment for Windows

This section provides a step-by-step guide for setting up your development environment on Windows.

MonoGame can work with most .NET compatible tools, but we recommend [Visual Studio 2022](https://visualstudio.microsoft.com/vs/)
```

The above markdown would generate the **title** `Setting up your development environment for Windows` and the **description** `This section provides a step-by-step guide for setting up your development environment on Windows.`

## Reference
No issue to reference, this PR was made as a request from @SimonDarksideJ 
