### PR TITLE
Update getting started link

### DIFF
--- a/website/content/index.njk
+++ b/website/content/index.njk
@@ -11,7 +11,7 @@ title: MonoGame
                 powerful cross-platform games
             </p>
             <div class="carousel-button-container">
-                <a type="button" class="btn btn-lrg mg-button" href="/articles/getting_started/index.html">
+                <a type="button" class="btn btn-lrg mg-button" href="https://docs.monogame.net/articles/getting_started/index.html">
                     Getting Started <i class="bi bi-arrow-right"></i>
                 </a>
                 <a type="button" class="btn btn-lrg mg-button" href="https://github.com/MonoGame/MonoGame">


### PR DESCRIPTION
This updates the getting started link to point to the new docs.monogame.net subdomain so there's no 404