### PR TITLE
Update index.njk (typographical error or a simple mistake in writing)

### DIFF
--- a/website/content/index.njk
+++ b/website/content/index.njk
@@ -178,7 +178,7 @@ title: MonoGame
                         <div class="mg-card-body d-flex flex-column h-100">
                             <div class="mg-card-title"><i class="bi bi-git"></i> Contribute</div>
                             <p>
-                                As a free and open-source project, the MonoGame Framework is is maintained by the MonoGame
+                                As a free and open-source project, the MonoGame Framework is maintained by the MonoGame
                                 Foundation and developed along side contributions made by the community.
                             </p>
                             <p class="mt-auto">Click to learn how to contribute</p>


### PR DESCRIPTION
just a notice a small typographical error or a simple mistake in writing, if you go to the index.njk for the web page, we will see under Open-Source -> contribute, an extra "is".

it is really not much of an issue, just wanted to help abit