### PR TITLE
Add wine setup scripts to site

### DIFF
--- a/website/.config/eleventy.config.passthrough.js
+++ b/website/.config/eleventy.config.passthrough.js
@@ -14,4 +14,5 @@ module.exports = function (config) {
     config.addPassthroughCopy({
         "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js": "/js/bootstrap.bundle.min.js"
     });
+    config.addPassthroughCopy({ "./website/content/public/downloads/**/*": "/downloads"});
 }

--- a/website/content/public/downloads/winesetup/net6_mgfxc_wine_setup.sh
+++ b/website/content/public/downloads/winesetup/net6_mgfxc_wine_setup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# This script is used to setup the needed Wine environment
+# so that mgfxc can be run on Linux / macOS systems.
+
+# check dependencies
+if ! type "wine64" > /dev/null 2>&1
+then
+    echo "wine64 not found"
+    exit 1
+fi
+
+if ! type "7z" > /dev/null 2>&1
+then
+    echo "7z not found"
+    exit 1
+fi
+
+# init wine stuff
+export WINEARCH=win64
+export WINEPREFIX=$HOME/.winemonogame
+wine64 wineboot
+
+TEMP_DIR="${TMPDIR:-/tmp}"
+SCRIPT_DIR="$TEMP_DIR/winemg2"
+mkdir -p "$SCRIPT_DIR"
+
+# disable wine crash dialog
+cat > "$SCRIPT_DIR"/crashdialog.reg <<_EOF_
+REGEDIT4
+[HKEY_CURRENT_USER\\Software\\Wine\\WineDbg]
+"ShowCrashDialog"=dword:00000000
+_EOF_
+
+pushd $SCRIPT_DIR
+wine64 regedit crashdialog.reg
+popd
+
+# get dotnet
+DOTNET_URL="https://download.visualstudio.microsoft.com/download/pr/44d08222-aaa9-4d35-b24b-d0db03432ab7/52a4eb5922afd19e8e0d03e0dbbb41a0/dotnet-sdk-6.0.302-win-x64.zip"
+curl $DOTNET_URL --output "$SCRIPT_DIR/dotnet-sdk.zip"
+7z x "$SCRIPT_DIR/dotnet-sdk.zip" -o"$WINEPREFIX/drive_c/windows/system32/"
+
+# get d3dcompiler_47
+FIREFOX_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/62.0.3/win64/ach/Firefox%20Setup%2062.0.3.exe"
+curl $FIREFOX_URL --output "$SCRIPT_DIR/firefox.exe"
+7z x "$SCRIPT_DIR/firefox.exe" -o"$SCRIPT_DIR/firefox_data/"
+cp -f "$SCRIPT_DIR/firefox_data/core/d3dcompiler_47.dll" "$WINEPREFIX/drive_c/windows/system32/d3dcompiler_47.dll"
+
+# append MGFXC_WINE_PATH env variable
+echo -e "\nexport MGFXC_WINE_PATH=$HOME/.winemonogame" >> ~/.profile
+echo -e "\nexport MGFXC_WINE_PATH=$HOME/.winemonogame" >> ~/.zprofile
+
+# cleanup
+rm -rf "$SCRIPT_DIR"

--- a/website/content/public/downloads/winesetup/net8_mgfxc_wine_setup.sh
+++ b/website/content/public/downloads/winesetup/net8_mgfxc_wine_setup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# This script is used to setup the needed Wine environment
+# so that mgfxc can be run on Linux / macOS systems.
+
+# check dependencies
+if ! type "wine64" > /dev/null 2>&1
+then
+    echo "wine64 not found"
+    exit 1
+fi
+
+if ! type "7z" > /dev/null 2>&1
+then
+    echo "7z not found"
+    exit 1
+fi
+
+# wine 8 is the minimum requirement for dotnet 8
+# wine --version will output "wine-#.# (Distro #.#.#)" or "wine-#.#"
+WINE_VERSION=$(wine --version 2>&1 | grep -oP 'wine-\d+' | sed 's/wine-//')
+if (( $WINE_VERSION < 8 )); then
+    echo "Wine version $WINE_VERSION is below the minimum required version (8.0)."
+    exit 1
+fi
+
+# init wine stuff
+export WINEARCH=win64
+export WINEPREFIX=$HOME/.winemonogame
+wine64 wineboot
+
+TEMP_DIR="${TMPDIR:-/tmp}"
+SCRIPT_DIR="$TEMP_DIR/winemg2"
+mkdir -p "$SCRIPT_DIR"
+
+# disable wine crash dialog
+cat > "$SCRIPT_DIR"/crashdialog.reg <<_EOF_
+REGEDIT4
+[HKEY_CURRENT_USER\\Software\\Wine\\WineDbg]
+"ShowCrashDialog"=dword:00000000
+_EOF_
+
+pushd $SCRIPT_DIR
+wine64 regedit crashdialog.reg
+popd
+
+# get dotnet
+DOTNET_URL="https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.201/dotnet-sdk-8.0.201-win-x64.zip"
+curl $DOTNET_URL --output "$SCRIPT_DIR/dotnet-sdk.zip"
+7z x "$SCRIPT_DIR/dotnet-sdk.zip" -o"$WINEPREFIX/drive_c/windows/system32/"
+
+# get d3dcompiler_47
+FIREFOX_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/62.0.3/win64/ach/Firefox%20Setup%2062.0.3.exe"
+curl $FIREFOX_URL --output "$SCRIPT_DIR/firefox.exe"
+7z x "$SCRIPT_DIR/firefox.exe" -o"$SCRIPT_DIR/firefox_data/"
+cp -f "$SCRIPT_DIR/firefox_data/core/d3dcompiler_47.dll" "$WINEPREFIX/drive_c/windows/system32/d3dcompiler_47.dll"
+
+# append MGFXC_WINE_PATH env variable
+echo -e "\nexport MGFXC_WINE_PATH=$HOME/.winemonogame" >> ~/.profile
+echo -e "\nexport MGFXC_WINE_PATH=$HOME/.winemonogame" >> ~/.zprofile
+
+# cleanup
+rm -rf "$SCRIPT_DIR"


### PR DESCRIPTION
## Description
This PR adds the mgfx_wine_setup.sh scripts to the website.  This was done following the suggestion from a conversation with @harry-cpp.  Both scripts have been added to the website, one for the current stable MonoGame 3.8.1.303 (`net6_mgfxc_wine_setup.sh`) and one for the current develop builds (`net8_mgfxc_wine_setup.sh`).

Once merged they will be available at
- https://monogame.net/downloads/net6_mgfxc_wine_setup.sh
- https://monogame.net/downloads/net8_mgfxc_wine_setup.sh

After merge, documentation will need to be updated to use the new urls for the wget download command

## Reason
The reason for doing this is that at the current moment there is no way for Linux or Mac users to actually do the wine setup correctly.  The current documentation points them to download the wine setup script from the `master` branch, but that one is not compatible with MonoGame 3.8.1.303.  There was the commit https://github.com/MonoGame/MonoGame/commit/158c0154ac18ed6102c65e24665c6a080ccb8ed2 to resolve this, however this was never cherry picked form `develop` into `master`.

Along with this, the `develop` branch is now setup for .net8.0.  Which means the wine setup script in the `develop` branch is for .net8.0 instead of .net6.0 which is what the current stable release of MonoGame needs.