### PR TITLE
Fix MacOS net8_mgfxc_wine_setup.sh

### DIFF
--- a/website/content/public/downloads/winesetup/net8_mgfxc_wine_setup.sh
+++ b/website/content/public/downloads/winesetup/net8_mgfxc_wine_setup.sh
@@ -17,7 +17,7 @@ fi
 
 # wine 8 is the minimum requirement for dotnet 8
 # wine --version will output "wine-#.# (Distro #.#.#)" or "wine-#.#"
-WINE_VERSION=$(wine --version 2>&1 | grep -oP 'wine-\d+' | sed 's/wine-//')
+WINE_VERSION=$(wine64 --version 2>&1 | grep -o 'wine-.' | sed 's/wine-//')
 if (( $WINE_VERSION < 8 )); then
     echo "Wine version $WINE_VERSION is below the minimum required version (8.0)."
     exit 1
@@ -44,7 +44,7 @@ wine64 regedit crashdialog.reg
 popd
 
 # get dotnet
-DOTNET_URL="https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.201/dotnet-sdk-8.0.201-win-x64.zip"
+DOTNET_URL="https://dotnetcli.azureedge.net/dotnet/Sdk/8.0.401/dotnet-sdk-8.0.401-win-x64.zip"
 curl $DOTNET_URL --output "$SCRIPT_DIR/dotnet-sdk.zip"
 7z x "$SCRIPT_DIR/dotnet-sdk.zip" -o"$WINEPREFIX/drive_c/windows/system32/"
 


### PR DESCRIPTION
Some issues with the install script caused errors on macos.  The default macos `grep` does not support the -P perl flag.  So use a basic regex instead.

We are trying to run `wine` in one part of the script, which will fail on M* Apple Macs because it is a 32bit executable. 

Also upgade to .net 8.0.401