### PR TITLE
Create net9_mgfxc_wine_setup.sh

### DIFF
--- a/website/content/public/downloads/winesetup/net9_mgfxc_wine_setup.sh
+++ b/website/content/public/downloads/winesetup/net9_mgfxc_wine_setup.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# This script is used to setup the needed Wine environment
+# so that mgfxc can be run on Linux / macOS systems.
+
+# check dependencies
+if ! type "wine64" > /dev/null 2>&1
+then
+    echo "wine64 not found"
+    exit 1
+fi
+
+if ! type "7z" > /dev/null 2>&1
+then
+    echo "7z not found"
+    exit 1
+fi
+
+# wine 8 is the minimum requirement for dotnet 8
+# wine --version will output "wine-#.# (Distro #.#.#)" or "wine-#.#"
+WINE_VERSION=$(wine64 --version 2>&1 | grep -o 'wine-.' | sed 's/wine-//')
+if (( $WINE_VERSION < 8 )); then
+    echo "Wine version $WINE_VERSION is below the minimum required version (8.0)."
+    exit 1
+fi
+
+# init wine stuff
+export WINEARCH=win64
+export WINEPREFIX=$HOME/.winemonogame
+wine64 wineboot
+
+TEMP_DIR="${TMPDIR:-/tmp}"
+SCRIPT_DIR="$TEMP_DIR/winemg2"
+mkdir -p "$SCRIPT_DIR"
+
+# disable wine crash dialog
+cat > "$SCRIPT_DIR"/crashdialog.reg <<_EOF_
+REGEDIT4
+[HKEY_CURRENT_USER\\Software\\Wine\\WineDbg]
+"ShowCrashDialog"=dword:00000000
+_EOF_
+
+pushd $SCRIPT_DIR
+wine64 regedit crashdialog.reg
+popd
+
+# get dotnet
+DOTNET_URL="https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.100-rc.1.24452.12/dotnet-sdk-9.0.100-rc.1.24452.12-win-x64.zip"
+curl $DOTNET_URL --output "$SCRIPT_DIR/dotnet-sdk.zip"
+7z x "$SCRIPT_DIR/dotnet-sdk.zip" -o"$WINEPREFIX/drive_c/windows/system32/"
+
+# get d3dcompiler_47
+FIREFOX_URL="https://download-installer.cdn.mozilla.net/pub/firefox/releases/62.0.3/win64/ach/Firefox%20Setup%2062.0.3.exe"
+curl $FIREFOX_URL --output "$SCRIPT_DIR/firefox.exe"
+7z x "$SCRIPT_DIR/firefox.exe" -o"$SCRIPT_DIR/firefox_data/"
+cp -f "$SCRIPT_DIR/firefox_data/core/d3dcompiler_47.dll" "$WINEPREFIX/drive_c/windows/system32/d3dcompiler_47.dll"
+
+# append MGFXC_WINE_PATH env variable
+echo -e "\nexport MGFXC_WINE_PATH=$HOME/.winemonogame" >> ~/.profile
+echo -e "\nexport MGFXC_WINE_PATH=$HOME/.winemonogame" >> ~/.zprofile
+
+# cleanup
+rm -rf "$SCRIPT_DIR"


### PR DESCRIPTION
Add a script for installing dotnet 9 under wine. 
There is a bug in dotnet 8 which can cause the dotnet process to fail to startup. dotnet 9 does not have this issue. 

We will need to update this script once dotnet 9 is released.