### PR TITLE
Fixed double admonitions

### DIFF
--- a/website/.config/markdownit-plugins/admonitions.js
+++ b/website/.config/markdownit-plugins/admonitions.js
@@ -196,9 +196,7 @@ function admonition(state, startLine, endLine, silent) {
 /// Adds the admonition parsing plugin to markdown-it
 ////////////////////////////////////////////////////////////////////////////////
 function admonitionPlugin(md) {
-    md.block.ruler.before("code", "admonition", admonition, {
-        alt: ["paragraph", "reference", "blockquote", "list"]
-    });
+    md.block.ruler.before("code", "admonition", admonition);
     md.renderer.rules["admonition_open"] = render;
     md.renderer.rules["admonition_title_open"] = render;
     md.renderer.rules["admonition_title_close"] = render;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fe8af0d1-2b65-415a-af14-47ae9dac1c0d)

It was possible for admonitions to be duplicated when placed after a list.

From what I can tell, the alt options weren't needed. It's still possible to have an admonition inside of a list without it.