### PR TITLE
Updated broken links and contributing link and text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # MonoGame Documentation
 
-This is the source for the [documentation published on MonoGame.net](http://www.monogame.net/documentation/).  It is rebuilt when the code changes and is published nightly to the website.
+This is the source for the [MonoGame.net website](https://www.monogame.net/).
 
 ## General Rules
 

--- a/website/content/about.njk
+++ b/website/content/about.njk
@@ -30,7 +30,7 @@ title: About
             {% endfor %}
         </div>
         <p>
-            You can read the foundation <a href="/foundation/">bylaws</a> or review the <a href="/blog/foundation">meeting minutes </a>
+            You can read the foundation <a href="https://docs.monogame.net/foundation/">bylaws</a> or review the <a href="/blog/meeting">meeting minutes </a>
             to keep track of our progress.
         </p>
     </section>


### PR DESCRIPTION
This is to resolve issue [#8533](https://github.com/MonoGame/MonoGame/issues/8533) that was submitted on the main MonoGame repo, but is actually for this bug on the website.

I also updated the link and text on the CONTRIBUTING.md as it mentioned this being the documentation repo and had an old link that 404s. With the documentation site and the website being separate I felt the text should probably be changed. Let me know if there are any concerns/issues with the change I made!
