### PR TITLE
GitHub Sponsors Link

### DIFF
--- a/website/content/donate.njk
+++ b/website/content/donate.njk
@@ -13,19 +13,28 @@ title: Donate
 <p>To ensure MonoGame continues to thrive into the future the MonoGame Foundation <b>needs your support</b>.  Your donations help us keep pace with advancing technology and new platforms, ensuring MonoGame remains a powerful tool for all game developers.</p>
 <p>If your time using MonoGame has been enjoyable, educational, or it helped create your successful game, consider giving back to the project.  Your contributions ensure a future where game development is accessible to everyone.</p>
 <p>Donate now and be a part of this exciting journey.</p>
-                    <a class="btn mg-patreon-button" type="button" href="https://www.patreon.com/bePatron?u=3142012" target="_blank">
-                        {% include 'svgs/logos/patreon.svg'%}
-                        Become a member!
-                    </a>
+    <br/>
+                    <div class="row justify-content-center">
+                        <div class="col-md-auto mb-2 mx-4">
+                            <a class="btn mg-patreon-button px-4" type="button" href="https://github.com/sponsors/MonoGame" target="_blank">
+                                    <i class="bi bi-heart"></i> GitHub
+                            </a>
+                        </div>
+                        <div class="col-md-auto mb-2 mx-4">
+                            <a class="btn mg-patreon-button px-4" type="button" href="https://www.patreon.com/bePatron?u=3142012" target="_blank">
+                                    {% include 'svgs/logos/patreon.svg'%} Patreon
+                            </a>
+                        </div>
+                    </div>
                 </div>
                 <div class="col-sm-3 patreon-stats">
                     <div class="patreon-stat monthly">
                         <span id="per-month"></span>
-                        <p>monthly</p>
+                        <p>Monthly</p>
                     </div>
                     <div class="patreon-stat patreon">
                         <span id="total-patrons"></span>
-                        <p>patrons</p>
+                        <p>Sponsors</p>
                     </div>
                 </div>
             </div>

--- a/website/content/public/js/patreon.js
+++ b/website/content/public/js/patreon.js
@@ -25,7 +25,16 @@
     if(data.included && data.included.length > 0) {
         const attributes = data.included[0].attributes;
         const patron_count = attributes.patron_count;
-        const pledge_sum = attributes.pledge_sum;
+        let pledge_sum = attributes.pledge_sum;
+
+        // HACK: Add in a few things from other services.
+        {
+            // Re-logic's monthly donation.
+            pledge_sum += 100000;
+
+            // TODO: Get GitHub sponsors and merge them with this.
+            // Requires a personal access token to do so.
+        }
 
         const total_patrons = document.getElementById('total-patrons');
         countUp(total_patrons, patron_count, (x) => x);


### PR DESCRIPTION
This is how it looks now:

![image](https://github.com/user-attachments/assets/7cb9a748-0e00-4eba-bf19-39f96221565d)


Also added Re-logic's monthly donation to the total for public accuracy.