### PR TITLE
Capitalize the "H" in "GitHub"

### DIFF
--- a/website/_includes/partials/_blog_footer.njk
+++ b/website/_includes/partials/_blog_footer.njk
@@ -1,6 +1,6 @@
 ### Support
 
-- [Financially](https://monogame.net/donate/) - several tiers and options available for Github, PayPal and Patreon.
+- [Financially](https://monogame.net/donate/) - several tiers and options available for GitHub, PayPal and Patreon.
 - The [MonoGame Store](https://store.monogame.net) - MonoGame branded gear and merchandise.
 
 ## Get Involved

--- a/website/content/blog/2024-12-01-a-year-in-review.md
+++ b/website/content/blog/2024-12-01-a-year-in-review.md
@@ -14,7 +14,7 @@ It has been a year since we announced that we received a very generous [donation
 
 ### So far in the last year we:
 
-* Increased recurring subscriptions (Patreon, Github & PayPal) to almost $2000 a month
+* Increased recurring subscriptions (Patreon, GitHub & PayPal) to almost $2000 a month
 * Refreshed the MonoGame website with more focus on the creators and their titles \- Thanks Chris (ArisTurtle)  
 * Overhauled the documentation site and increased the content by more than 500%, with even more to come  
 * Released 3.8.2 (.NET 8)

--- a/website/content/bounties.njk
+++ b/website/content/bounties.njk
@@ -13,7 +13,7 @@ description: The MonoGame Foundation uses a bounty system to propose paid incent
         </p>
 		<p>
             The list of all open bounties is available on <a href="https://github.com/MonoGame/MonoGame/issues/8120">the
-			project's Github repository</a>.
+			project's GitHub repository</a>.
         </p>
     </section>
 

--- a/website/content/index.njk
+++ b/website/content/index.njk
@@ -15,7 +15,7 @@ title: MonoGame
                     Getting Started <i class="bi bi-mortarboard"></i>
                 </a>
                 <a type="button" class="btn btn-lrg mg-button" href="https://github.com/MonoGame/MonoGame">
-                    Github <i class="bi bi-github"></i>
+                    GitHub <i class="bi bi-github"></i>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
It's capitalized in other places on the site, and in official GitHub branding, so let's make it consistent everywhere :)