### PR TITLE
Fix broken link and update footer year

### DIFF
--- a/website/_data/foundation.json
+++ b/website/_data/foundation.json
@@ -27,6 +27,6 @@
     {
         "name": "Thomas Altenburger",
         "title": "Board Member",
-        "github": "mrhelmut"
+        "github": "ThomasFOG"
     }
 ]

--- a/website/_includes/partials/_footer.njk
+++ b/website/_includes/partials/_footer.njk
@@ -62,7 +62,7 @@
 
         <div class="d-flex flex-column flex-sm-row justify-content-between align-items-center gap-3 py-4 my-4">
             <div>
-                © 2009-2024 MonoGame Foundation, Inc. is a 501(c)(3) non-profit. EIN 93-3803929<br/>Designed with
+                © 2009-2025 MonoGame Foundation, Inc. is a 501(c)(3) non-profit. EIN 93-3803929<br/>Designed with
                 <span class="text-danger">❤</span>
                 by
                 <a href="https://github.com/MonoGame/monogame.github.io/graphs/contributors">MonoGame Community</a>


### PR DESCRIPTION
Fixed a broken link on about and updated the footer to include the current year in the copyright.