### PR TITLE
Multiple resource tags

### DIFF
--- a/website/content/resources.njk
+++ b/website/content/resources.njk
@@ -26,7 +26,7 @@ permalink: resources/{{ (category | slugify) if category !== "all" }}/
         <div id="resource-gallery" class="mg-item-grid mg-grid-2">
             {% for resource in resources %}
                 {% if category in resource.tags or category === "all" %}
-                    <a class="mg-no-link hide-external-icon" href="{{ resource.url }}" title="{{ resource.title }}">
+                    <a class="mg-no-link hide-external-icon" href="{{ resource.url }}">
                         <div class="mg-resource-container mg-box-shadow"
                              style="background-image: url('{{ resource.cover }}');">
                             <div class="transparent-overlay"></div>

--- a/website/content/resources.njk
+++ b/website/content/resources.njk
@@ -32,8 +32,23 @@ permalink: resources/{{ (category | slugify) if category !== "all" }}/
                             <div class="transparent-overlay"></div>
                             <div class="mg-resource-tags">
                                 {% for tag in resource.tags %}
-                                    <div>{{ tag }}</div>
+                                    {% if loop.index <= 3 %}
+                                        <div>{{ tag }}</div>
+                                    {% endif %}
                                 {% endfor %}
+
+                                {% if resource.tags.length > 3 %}
+                                    {% set additionalTags = '' %}
+                                    {% for tag in resource.tags %}
+                                        {% if loop.index0 >= 3 %}
+                                            {% set additionalTags = additionalTags + tag + '<br/>' %}
+                                        {% endif %}
+                                    {% endfor %}
+                                    <div data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" data-bs-title="{{ additionalTags }}">
+                                        <div>+{{ resource.tags.length - 3 }}</div>
+                                    </div>
+                                {% endif %}
+
                             </div>
                             <div class="mg-resource-footer">
                                 <div class="mg-resource-title">{{ resource.title }}</div>
@@ -45,4 +60,11 @@ permalink: resources/{{ (category | slugify) if category !== "all" }}/
             {% endfor %}
         </div>
     </section>
+{% endblock %}
+
+{% block scripts %}
+<script type="text/javascript">
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+</script>
 {% endblock %}


### PR DESCRIPTION
If a resource listed has more than three tags, then the tags wrap around and can get crowded. 

Here is an example, with 7 tags

![image](https://github.com/user-attachments/assets/f8588b0b-7445-4ece-8e7c-4e2a7a7b594c)


This PR adds logic to the `resource.njk` template to
- When a resource contains more than 3 tags, a 4th element is displayed with just the additional number of tags (e.g. if a resource has 4 tags, the element will say "+1"
- When the 4th element is hovered, a tool tip is enabled that lists the additional tags

Here is a video example of this in action


https://github.com/user-attachments/assets/161eb4b7-708f-4d1c-90c3-bef66f3fa189

