### PR TITLE
Update net9_mgfxc_wine_setup.sh

### DIFF
--- a/website/content/public/downloads/winesetup/net9_mgfxc_wine_setup.sh
+++ b/website/content/public/downloads/winesetup/net9_mgfxc_wine_setup.sh
@@ -17,7 +17,7 @@ fi
 
 # wine 8 is the minimum requirement for dotnet 8
 # wine --version will output "wine-#.# (Distro #.#.#)" or "wine-#.#"
-WINE_VERSION=$(wine64 --version 2>&1 | grep -o 'wine-.' | sed 's/wine-//')
+WINE_VERSION=$(wine64 --version 2>&1 | grep -o 'wine-.' | sed 's/wine-//' | sed 's/\.//')
 if (( $WINE_VERSION < 8 )); then
     echo "Wine version $WINE_VERSION is below the minimum required version (8.0)."
     exit 1

--- a/website/content/public/downloads/winesetup/net9_mgfxc_wine_setup.sh
+++ b/website/content/public/downloads/winesetup/net9_mgfxc_wine_setup.sh
@@ -17,7 +17,7 @@ fi
 
 # wine 8 is the minimum requirement for dotnet 8
 # wine --version will output "wine-#.# (Distro #.#.#)" or "wine-#.#"
-WINE_VERSION=$(wine64 --version 2>&1 | grep -o 'wine-.' | sed 's/wine-//' | sed 's/\.//')
+WINE_VERSION=$(wine64 --version 2>&1 | grep -o 'wine-..' | sed 's/wine-//' | sed 's/\.//')
 if (( $WINE_VERSION < 8 )); then
     echo "Wine version $WINE_VERSION is below the minimum required version (8.0)."
     exit 1


### PR DESCRIPTION
Allow wine10.0 to be installed.

This file is used by https://github.com/MonoGame/MonoGame/blob/develop/.github/workflows/main.yml#L62. 
The GitHub Actions are installing `wine 10.0` this breaks the version parsing in this script. 
Instead of getting `10` as we expect we get `1` as the script only takes the first digit of the version. 
The script has been updated to allow multiple digits and to strip out the trailing `.` if one is present.