### PR TITLE
Create wrapper script for wine64 symlink

### DIFF
--- a/website/content/public/downloads/winesetup/net6_mgfxc_wine_setup.sh
+++ b/website/content/public/downloads/winesetup/net6_mgfxc_wine_setup.sh
@@ -61,8 +61,12 @@ then
     echo -e "\nexport PATH=\"\$PATH:$HOME/.winemonogame\"" >> ~/.profile
     echo -e "\nexport PATH=\"\$PATH:$HOME/.winemonogame\"" >> ~/.zprofile
 
-    WINEPATH=$(which $WINEEXECUTABLE)
-    ln -s "$WINEPATH" "$HOME/.winemonogame/wine64"
+    # create a wine wrapper script to work around oddities with symlinked wine64
+    echo -e "#\!/bin/bash\nwine \"\$@\"" > "$HOME/.winemonogame/wine_wrapper.sh"
+    chmod +x "$HOME/.winemonogame/wine_wrapper.sh"
+
+    # symlink wine64 to our wrapper script
+    ln -s "$HOME/.winemonogame/wine_wrapper.sh" "$HOME/.winemonogame/wine64"
 fi
 
 # cleanup

--- a/website/content/public/downloads/winesetup/net8_mgfxc_wine_setup.sh
+++ b/website/content/public/downloads/winesetup/net8_mgfxc_wine_setup.sh
@@ -69,8 +69,12 @@ then
     echo -e "\nexport PATH=\"\$PATH:$HOME/.winemonogame\"" >> ~/.profile
     echo -e "\nexport PATH=\"\$PATH:$HOME/.winemonogame\"" >> ~/.zprofile
 
-    WINEPATH=$(which $WINEEXECUTABLE)
-    ln -s "$WINEPATH" "$HOME/.winemonogame/wine64"
+    # create a wine wrapper script to work around oddities with symlinked wine64
+    echo -e "#\!/bin/bash\nwine \"\$@\"" > "$HOME/.winemonogame/wine_wrapper.sh"
+    chmod +x "$HOME/.winemonogame/wine_wrapper.sh"
+
+    # symlink wine64 to our wrapper script
+    ln -s "$HOME/.winemonogame/wine_wrapper.sh" "$HOME/.winemonogame/wine64"
 fi
 
 # cleanup

--- a/website/content/public/downloads/winesetup/net9_mgfxc_wine_setup.sh
+++ b/website/content/public/downloads/winesetup/net9_mgfxc_wine_setup.sh
@@ -69,8 +69,12 @@ then
     echo -e "\nexport PATH=\"\$PATH:$HOME/.winemonogame\"" >> ~/.profile
     echo -e "\nexport PATH=\"\$PATH:$HOME/.winemonogame\"" >> ~/.zprofile
 
-    WINEPATH=$(which $WINEEXECUTABLE)
-    ln -s "$WINEPATH" "$HOME/.winemonogame/wine64"
+    # create a wine wrapper script to work around oddities with symlinked wine64
+    echo -e "#\!/bin/bash\nwine \"\$@\"" > "$HOME/.winemonogame/wine_wrapper.sh"
+    chmod +x "$HOME/.winemonogame/wine_wrapper.sh"
+
+    # symlink wine64 to our wrapper script
+    ln -s "$HOME/.winemonogame/wine_wrapper.sh" "$HOME/.winemonogame/wine64"
 fi
 
 # cleanup


### PR DESCRIPTION
I was having issues getting shader compilation to work on my M4 Macbook Pro. I followed all the instructions and didn't have any luck at all. After some digging, I found this [Reddit post](https://www.reddit.com/r/monogame/comments/18wnhl8/linux_effect_compilation_error_with_wine64/) suggesting it works if a script which re-executes `wine` is used - and it does!

This PR adds a simple wrapper script and symlinks to *that* instead of `wine` directly.

I'm not sure why this works (and why it doesn't work otherwise), but the existing symlink created by the script does *not*, so this is definitely something which should be done (at least until `mgfxc` or whatever stops trying to use `wine64`).