### PR TITLE
Loosen the NDA requirements

### DIFF
--- a/website/content/bounties.njk
+++ b/website/content/bounties.njk
@@ -28,7 +28,7 @@ description: The MonoGame Foundation uses a bounty system to propose paid incent
             Once the date has been reached the bounty coordinator will review the applications. If there are no applicants, the bounty will remain open.
             With input from the rest of the board members a successful applicant will be chosen. The bounty coordinator will then let you know of the decision.
             The decision will also be made public on the specific bounty page. If the decision is favorable, a service agreement will
-            be proposed to you to legally bind both parties. You will also be required to sign a Non-Disclosure Agreement with the Foundation.
+            be proposed to you to legally bind both parties. You may also be required to sign a Non-Disclosure Agreement with the Foundation.
         </p>
 		<p>
 			The Foundation board will consider your expertise and proposed schedule. Unless specified, only one application
@@ -44,8 +44,8 @@ description: The MonoGame Foundation uses a bounty system to propose paid incent
             <span class="fw-bold">Before you apply for fulfilling a bounty, please note the following requirements:</span>
         </p>
 		<ul>
-		  <li>For US citizens you must provide a <a href="https://www.irs.gov/forms-pubs/about-form-w-9">W-9</a> form along with your signed NDA when selected for a bounty.</li>
-          <li>For non-US citizens you need to provide the correct <a href="https://www.irs.gov/forms-pubs/about-form-w-8">W-8</a> form along with your signed NDA when selected for a bounty </li>
+		  <li>For US citizens you must provide a <a href="https://www.irs.gov/forms-pubs/about-form-w-9">W-9</a> form along with your signed NDA (if required) when selected for a bounty.</li>
+          <li>For non-US citizens you need to provide the correct <a href="https://www.irs.gov/forms-pubs/about-form-w-8">W-8</a> form along with your signed NDA (if required) when selected for a bounty </li>
 		  <li>Your country of registration must not be under commercial embargo from the United States of America.</li>
 		  <li>Your bank account must not be from a bank that is under commercial embargo from the United States of America.</li>
 		  <li>


### PR DESCRIPTION
We should only require an NDA if the bounty relates to closed source platforms. For bounties dealing with the open source repo the contributor agreement should be enough.