### PR TITLE
Add multi-tag filtering on Resources page

### DIFF
--- a/website/.config/collections/resources.js
+++ b/website/.config/collections/resources.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const resources = require('../../_data/resources.json');
+
+/** @param {import("@11ty/eleventy/src/TemplateCollection")} api */
+function resourcesCollection(api) {
+    return resources;
+}
+
+module.exports = resourcesCollection;

--- a/website/_includes/macros/create_multi_tag_filter.njk
+++ b/website/_includes/macros/create_multi_tag_filter.njk
@@ -4,7 +4,7 @@
 {% macro create_multi_tag_filter(categories) %}
     <section class="container-xxl my-5">
         <h3 class="fw-bold">Categories</h3>
-        <p>Click categories to filter results. Hold <kbd>Shift</kbd> to select multiple categories and show items that have ALL selected tags.</p>
+        <p>Click categories to filter results. Hold <kbd>Shift</kbd> to select multiple categories and show items that have all selected tags.</p>
         <div class="d-flex flex-row flex-wrap gap-3 mb-1" id="tag-filter-container">
             {% for category in categories %}
                 {% if category !== "all" %}

--- a/website/_includes/macros/create_multi_tag_filter.njk
+++ b/website/_includes/macros/create_multi_tag_filter.njk
@@ -1,0 +1,31 @@
+{# Creates a section containing tags from the given categories that can be #}
+{# used to click to filter the items on a page based on those categories #}
+{# This version supports multi-tag filtering with client-side JavaScript #}
+{% macro create_multi_tag_filter(categories) %}
+    <section class="container-xxl my-5">
+        <h3 class="fw-bold">Categories</h3>
+        <p>Click categories to filter results. Hold <kbd>Shift</kbd> to select multiple categories and show items that have ALL selected tags.</p>
+        <div class="d-flex flex-row flex-wrap gap-3 mb-1" id="tag-filter-container">
+            {% for category in categories %}
+                {% if category !== "all" %}
+                    <button type="button"
+                            class="btn mg-outline-button d-flex justify-content-center text-capitalize fw-bold tag-filter-btn"
+                            data-tag="{{ category }}">
+                        {{ category }}
+                    </button>
+                {% endif %}
+            {% endfor %}
+        </div>
+        <div class="mt-3">
+            <button type="button" 
+                    class="btn btn-outline-secondary fw-bold px-4 py-2" 
+                    id="clear-filters">
+                Clear All Filters
+            </button>
+        </div>
+        <div class="mt-3 text-muted" id="filter-status">
+            <span id="results-count">{{ "All results" }}</span> • 
+            <span id="active-filters">No filters active</span>
+        </div>
+    </section>
+{% endmacro %}

--- a/website/content/public/js/multiTagFilter.js
+++ b/website/content/public/js/multiTagFilter.js
@@ -149,7 +149,7 @@
                     activeFiltersElement.textContent = `Showing: ${tagList}`;
                 } else {
                     const tagList = Array.from(this.selectedTags).join(' + ');
-                    activeFiltersElement.textContent = `Showing items with ALL: ${tagList}`;
+                    activeFiltersElement.textContent = `Showing items with: ${tagList}`;
                 }
             }
         }

--- a/website/content/public/js/multiTagFilter.js
+++ b/website/content/public/js/multiTagFilter.js
@@ -17,8 +17,7 @@
             }
 
             this.bindEvents();
-            
-            // Initial update
+                        
             this.updateDisplay();
             this.updateFilterStatus();
         }
@@ -81,6 +80,9 @@
                 button.classList.add('active');
                 button.setAttribute('aria-pressed', 'true');
             }
+            
+            // Remove focus to prevent button from appearing highlighted after click
+            button.blur();
         }
 
         clearAllFilters() {
@@ -113,12 +115,12 @@
         }
 
         shouldShowItem(itemTags) {
-            // If no tags selected, show all items
+            // If no tags selected show all
             if (this.selectedTags.size === 0) {
                 return true;
             }
 
-            // Check if item has ALL of the selected tags (AND logic)
+            // Check if item has ALL of the selected tags
             return Array.from(this.selectedTags).every(selectedTag => 
                 itemTags.some(itemTag => itemTag === selectedTag)
             );
@@ -152,8 +154,7 @@
             }
         }
     }
-
-    // Initialize resource tag filter when DOM is ready
+    
     document.addEventListener('DOMContentLoaded', function() {
         const resourceGallery = document.getElementById('resource-gallery');
         if (resourceGallery) {

--- a/website/content/public/js/multiTagFilter.js
+++ b/website/content/public/js/multiTagFilter.js
@@ -1,0 +1,163 @@
+(() => {
+    'use strict';
+
+    class ResourceTagFilter {
+        constructor() {
+            this.container = document.getElementById('resource-gallery');
+            this.items = this.container ? Array.from(this.container.children) : [];
+            this.selectedTags = new Set();
+            
+            this.init();
+        }
+
+        init() {
+            if (!this.container) {
+                console.warn('Resource gallery not found');
+                return;
+            }
+
+            this.bindEvents();
+            
+            // Initial update
+            this.updateDisplay();
+            this.updateFilterStatus();
+        }
+
+        getItemTags(item) {
+            // Resources use data-tags attribute
+            if (item.dataset.tags) {
+                return item.dataset.tags.split(',').map(tag => tag.trim().toLowerCase()).filter(tag => tag);
+            }
+            return [];
+        }
+
+        bindEvents() {
+            // Tag filter buttons
+            const tagButtons = document.querySelectorAll('.tag-filter-btn');
+            tagButtons.forEach(button => {
+                button.addEventListener('click', (e) => this.handleTagClick(e));
+            });
+
+            // Clear all button
+            const clearButton = document.getElementById('clear-filters');
+            if (clearButton) {
+                clearButton.addEventListener('click', () => this.clearAllFilters());
+            }
+
+            // Keyboard shortcuts
+            document.addEventListener('keydown', (e) => {
+                if (e.target.classList.contains('tag-filter-btn')) {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        this.handleTagClick(e);
+                    }
+                }
+            });
+        }
+
+        handleTagClick(event) {
+            const button = event.target;
+            const tag = button.dataset.tag.toLowerCase();
+            
+            // Handle multi-select with Shift key
+            if (event.shiftKey) {
+                this.toggleTag(tag, button);
+            } else {
+                this.clearAllFilters();
+                this.toggleTag(tag, button);
+            }
+            
+            this.updateDisplay();
+            this.updateFilterStatus();
+        }
+
+        toggleTag(tag, button) {
+            if (this.selectedTags.has(tag)) {
+                this.selectedTags.delete(tag);
+                button.classList.remove('active');
+                button.setAttribute('aria-pressed', 'false');
+            } else {
+                this.selectedTags.add(tag);
+                button.classList.add('active');
+                button.setAttribute('aria-pressed', 'true');
+            }
+        }
+
+        clearAllFilters() {
+            this.selectedTags.clear();
+            const tagButtons = document.querySelectorAll('.tag-filter-btn');
+            tagButtons.forEach(button => {
+                button.classList.remove('active');
+                button.setAttribute('aria-pressed', 'false');
+            });
+            this.updateDisplay();
+            this.updateFilterStatus();
+        }
+
+        updateDisplay() {
+            let visibleCount = 0;
+            
+            this.items.forEach(item => {
+                const itemTags = this.getItemTags(item);
+                const shouldShow = this.shouldShowItem(itemTags);
+                
+                if (shouldShow) {
+                    item.style.display = '';
+                    item.classList.remove('d-none');
+                    visibleCount++;
+                } else {
+                    item.style.display = 'none';
+                    item.classList.add('d-none');
+                }
+            });
+        }
+
+        shouldShowItem(itemTags) {
+            // If no tags selected, show all items
+            if (this.selectedTags.size === 0) {
+                return true;
+            }
+
+            // Check if item has ALL of the selected tags (AND logic)
+            return Array.from(this.selectedTags).every(selectedTag => 
+                itemTags.some(itemTag => itemTag === selectedTag)
+            );
+        }
+
+        updateFilterStatus() {
+            const resultsCountElement = document.getElementById('results-count');
+            const activeFiltersElement = document.getElementById('active-filters');
+            
+            if (resultsCountElement) {
+                const visibleCount = this.items.filter(item => 
+                    !item.classList.contains('d-none') && item.style.display !== 'none'
+                ).length;
+                
+                resultsCountElement.textContent = 
+                    visibleCount === this.items.length 
+                        ? 'All results' 
+                        : `${visibleCount} of ${this.items.length} results`;
+            }
+            
+            if (activeFiltersElement) {
+                if (this.selectedTags.size === 0) {
+                    activeFiltersElement.textContent = 'No filters active';
+                } else if (this.selectedTags.size === 1) {
+                    const tagList = Array.from(this.selectedTags).join(', ');
+                    activeFiltersElement.textContent = `Showing: ${tagList}`;
+                } else {
+                    const tagList = Array.from(this.selectedTags).join(' + ');
+                    activeFiltersElement.textContent = `Showing items with ALL: ${tagList}`;
+                }
+            }
+        }
+    }
+
+    // Initialize resource tag filter when DOM is ready
+    document.addEventListener('DOMContentLoaded', function() {
+        const resourceGallery = document.getElementById('resource-gallery');
+        if (resourceGallery) {
+            new ResourceTagFilter();
+        }
+    });
+})();

--- a/website/content/resources-multi-tag.njk
+++ b/website/content/resources-multi-tag.njk
@@ -1,0 +1,66 @@
+---
+title: Resources
+---
+{% extends "layouts/base.layout.njk" %}
+{% from 'macros/create_multi_tag_filter.njk' import create_multi_tag_filter %}
+
+{% block content %}
+    <section class="container-xxl my-5">
+        <h1 id="monogame-resource" class="fw-bold"><a href="#monogame-resource">MonoGame Resources</a></h1>
+        <p>
+            Here's a list of MonoGame resources that can help you on your journey.
+            If you have a resource you'd like to share, please <a href="mailto:biz@monogame.net?subject=New%20Resource&body=Hi,%20Please%20add%20this%20resource%20to%20your%20list:%0A%0ATitle:%20%0AAuthor:%20%0AResource%20URL:%20%0AImage%20URL:%20%0ATags:%20">
+                Email Us
+            </a>.
+        </p>
+    </section>
+
+    {{ create_multi_tag_filter(collections.resourceTags, "resource-gallery") }}
+
+    <section class="container-xxl mb-5">
+        <div id="resource-gallery" class="mg-item-grid mg-grid-2">
+            {% for resource in resources %}
+                <a class="mg-no-link hide-external-icon" 
+                   href="{{ resource.url }}"
+                   data-tags="{{ resource.tags | join(',') | lower }}">
+                    <div class="mg-resource-container mg-box-shadow"
+                         style="background-image: url('{{ resource.cover }}');">
+                        <div class="transparent-overlay"></div>
+                        <div class="mg-resource-tags">
+                            {% for tag in resource.tags %}
+                                {% if loop.index <= 3 %}
+                                    <div>{{ tag }}</div>
+                                {% endif %}
+                            {% endfor %}
+
+                            {% if resource.tags.length > 3 %}
+                                {% set additionalTags = '' %}
+                                {% for tag in resource.tags %}
+                                    {% if loop.index0 >= 3 %}
+                                        {% set additionalTags = additionalTags + tag + '<br/>' %}
+                                    {% endif %}
+                                {% endfor %}
+                                <div data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom" data-bs-title="{{ additionalTags }}">
+                                    <div>+{{ resource.tags.length - 3 }}</div>
+                                </div>
+                            {% endif %}
+
+                        </div>
+                        <div class="mg-resource-footer">
+                            <div class="mg-resource-title">{{ resource.title }}</div>
+                            <div class="mg-resource-author">by {{ resource.author }}</div>
+                        </div>
+                    </div>
+                </a>
+            {% endfor %}
+        </div>
+    </section>
+{% endblock %}
+
+{% block scripts %}
+<script type="text/javascript" src="/js/multiTagFilter.js"></script>
+<script type="text/javascript">
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+</script>
+{% endblock %}

--- a/website/content/resources.njk
+++ b/website/content/resources.njk
@@ -8,6 +8,7 @@ permalink: resources/{{ (category | slugify) if category !== "all" }}/
 ---
 {% extends "layouts/base.layout.njk" %}
 {% from 'macros/create_category_filter.njk' import create_category_filter %}
+{% from 'macros/create_multi_tag_filter.njk' import create_multi_tag_filter %}
 
 {% block content %}
     <section class="container-xxl my-5">
@@ -20,13 +21,21 @@ permalink: resources/{{ (category | slugify) if category !== "all" }}/
         </p>
     </section>
 
-    {{ create_category_filter(collections.resourceTags, "/resources/", page.url) }}
+    {% if category === "all" %}
+        {# Show multi-tag filter only on the main resources page #}
+        {{ create_multi_tag_filter(collections.resourceTags) }}
+    {% else %}
+        {# Show single-tag filter on category pages #}
+        {{ create_category_filter(collections.resourceTags, "/resources/", page.url) }}
+    {% endif %}
 
     <section class="container-xxl mb-5">
         <div id="resource-gallery" class="mg-item-grid mg-grid-2">
             {% for resource in resources %}
                 {% if category in resource.tags or category === "all" %}
-                    <a class="mg-no-link hide-external-icon" href="{{ resource.url }}">
+                    <a class="mg-no-link hide-external-icon" 
+                       href="{{ resource.url }}"
+                       data-tags="{{ resource.tags | join(',') | lower }}">
                         <div class="mg-resource-container mg-box-shadow"
                              style="background-image: url('{{ resource.cover }}');">
                             <div class="transparent-overlay"></div>
@@ -63,6 +72,9 @@ permalink: resources/{{ (category | slugify) if category !== "all" }}/
 {% endblock %}
 
 {% block scripts %}
+{% if category === "all" %}
+<script type="text/javascript" src="/js/multiTagFilter.js"></script>
+{% endif %}
 <script type="text/javascript">
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
     const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));


### PR DESCRIPTION
This is an option to add the feature request on #205 

<img width="1043" height="644" alt="image" src="https://github.com/user-attachments/assets/610b7ae3-3219-421b-934d-a193b8a285d1" />

You can use Shift + Click to select or deselect individual tags. The results are then filtered by all of the selected Tags. There is a Clear All Button that resets the selection to the default state. There is also some text underneath just explaining the number of results and which tags are currently being shown.


The current implementation leaves the original filtering using the routes too, in case anybody has bookmarks or saved links to specific tags on the resources page (screenshot below). If you just land on the /resources link you will get the new experience, but if you do something like /resources/2D/ it will have the previous experience since the new one does not use routes.

However, this can be simplified to just replace the functionality with the new functionality if that is okay since it does add additional files and complexity. Figured I'd rather be safe than sorry and give an implementation that does not cause any impact to existing links first. 

<img width="1061" height="639" alt="image" src="https://github.com/user-attachments/assets/9a32b31f-0b83-4a9c-af86-586a80fb04c1" />

