### PR TITLE
Reduce the size of the hero carousel by 20%

### DIFF
--- a/website/content/public/css/main.css
+++ b/website/content/public/css/main.css
@@ -396,7 +396,7 @@ blockquote {
 *** Style classes specific to the / home page
 *******************************************************************************/
 .carousel {
-  height: calc(100vh - var(--navbar-height));
+  height: calc(80vh - var(--navbar-height));
 }
 
 .carousel-content {


### PR DESCRIPTION
This reduces the height of the hero carousel on the home page by 20% so that viewers can see there is move below it and to scroll down.

Reference:

- PR #237 
- Closes #239 