### PR TITLE
Resources: Split MLEM and MLEM.Ui into two separate entries

### DIFF
--- a/website/_data/resources.json
+++ b/website/_data/resources.json
@@ -203,17 +203,25 @@
         ]
     },
     {
-        "title": "MLEM and MLEM.Ui",
+        "title": "MLEM",
         "author": "Ellpeck",
         "cover": "https://raw.githubusercontent.com/Ellpeck/MLEM/main/Media/Logo.png",
         "url": "https://mlem.ellpeck.de/",
         "pixelart": false,
         "tags": [
-            "libraries",
+            "libraries"
+        ]
+    },
+    {
+        "title": "MLEM.Ui",
+        "author": "Ellpeck",
+        "cover": "https://raw.githubusercontent.com/Ellpeck/MLEM/main/Media/Ui.gif",
+        "url": "https://mlem.ellpeck.de/articles/ui.html",
+        "pixelart": false,
+        "tags": [
             "ui"
         ]
-    }
-    ,
+    },
     {
         "title": "Contentless",
         "author": "Ellpeck",


### PR DESCRIPTION
Hi! I hope you don't mind me doing this little change through a pull request.

Essentially, while MLEM.Ui is both named after & shares a repository and docs site with the other components of MLEM, it's also the most feature-rich component. Because of this, I wanted to highlight it as its own library :)
