### PR TITLE
Update bounty eligibility requirements

### DIFF
--- a/website/content/bounties.njk
+++ b/website/content/bounties.njk
@@ -20,6 +20,11 @@ description: The MonoGame Foundation uses a bounty system to propose paid incent
     <section class="container-xxl mb-5">
         <h1 id="how" class="fw-bold"><a href="#how">How do bounties work?</a></h1>
         <p>
+            Bounites will only be given out to *known*, *reliable* contributors. Unless there is a history of providing good quality PR's on this project.
+            You should provide your PR history for this project when applying for any bounty.
+            This measure is being taken to ensure the high quality of the code being included in MonoGame.
+        </p>
+        <p>
             If you would like to propose your services to fulfill a bounty, please send us your references and a proposed schedule to
 			complete the bounty by e-mail (please indicate which bounty you are applying to): <a href="mailto:biz@monogame.net">biz@monogame.net</a>
         </p>

--- a/website/content/bounties.njk
+++ b/website/content/bounties.njk
@@ -20,7 +20,8 @@ description: The MonoGame Foundation uses a bounty system to propose paid incent
     <section class="container-xxl mb-5">
         <h1 id="how" class="fw-bold"><a href="#how">How do bounties work?</a></h1>
         <p>
-            Bounites will only be given out to *known*, *reliable* contributors. Unless there is a history of providing good quality PR's on this project.
+            Bounites will *only* be given out to *known*, *reliable* contributors.
+            Unless there is a history of providing good quality PR's on this project, your application will be rejected.
             You should provide your PR history for this project when applying for any bounty.
             This measure is being taken to ensure the high quality of the code being included in MonoGame.
         </p>


### PR DESCRIPTION
Given the restrictions we apply in all of our repo's on the use of LLM's. We should start restricting the handing out of bounties to known and reliable members of the MonoGame community. This will help us ensure the quality of the code we are merging and paying for.